### PR TITLE
Add anchore engine chart v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Anchore Charts
 
-A collection of anchore charts for tooling and integrations.
-
-The charts in this repository are available from the Anchore Charts Repository at:
+A collection of anchore charts for tooling and integrations. The charts in this repository are available from the Anchore Charts Repository at:
 
 http://charts.anchore.io
 
-http://charts.anchore.io/test
+## Installing Charts
+```
+$ helm repo add anchore https://charts.anchore.io
+$ helm search repo anchore
+$ helm install my-release anchore/<chart>
+```
+
 
 ## Contributing
 

--- a/ct-config.yaml
+++ b/ct-config.yaml
@@ -1,3 +1,5 @@
 remote: origin
 chart-dirs:
-- stable
+  - stable
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami

--- a/stable/anchore-engine/.gitignore
+++ b/stable/anchore-engine/.gitignore
@@ -1,0 +1,1 @@
+examples/

--- a/stable/anchore-engine/.helmignore
+++ b/stable/anchore-engine/.helmignore
@@ -1,0 +1,5 @@
+.git
+
+# OWNERS file for Kubernetes
+OWNERS
+

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+name: anchore-engine
+version: 1.6.9
+appVersion: 0.7.2
+description: Anchore container analysis and policy evaluation engine service
+keywords:
+ - analysis
+ - docker
+ - anchore
+ - "anchore-engine"
+ - image
+ - security
+ - vulnerability
+ - scanner
+home: https://anchore.com
+sources:
+ - https://github.com/anchore/anchore-engine
+maintainers:
+ - name: zhill
+   email: zach@anchore.com
+ - name: btodhunter
+   email: bradyt@anchore.com
+engine: gotpl
+icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: anchore-engine
-version: 1.6.9
-appVersion: 0.7.2
+version: 1.7.0
+appVersion: 0.7.3
 description: Anchore container analysis and policy evaluation engine service
 keywords:
  - analysis

--- a/stable/anchore-engine/OWNERS
+++ b/stable/anchore-engine/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- zhill
+- btodhunter
+reviewers:
+- zhill
+- nurmi
+- btodhunter

--- a/stable/anchore-engine/OWNERS
+++ b/stable/anchore-engine/OWNERS
@@ -1,7 +1,0 @@
-approvers:
-- zhill
-- btodhunter
-reviewers:
-- zhill
-- nurmi
-- btodhunter

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -1,0 +1,653 @@
+# Anchore Engine Helm Chart
+
+This chart deploys the Anchore Engine docker container image analysis system. Anchore Engine requires a PostgreSQL database (>=9.6) which may be handled by the chart or supplied externally, and executes in a service based architecture utilizing the following Anchore Engine services: External API, SimpleQueue, Catalog, Policy Engine, and Analyzer.
+
+This chart can also be used to install the following Anchore Enterprise services: GUI, RBAC, Reporting, Notifications & On-premises Feeds. Enterprise services require a valid Anchore Enterprise License as well as credentials with access to the private DockerHub repository hosting the images. These are not enabled by default.
+
+Each of these services can be scaled and configured independently.
+
+See [Anchore Engine](https://github.com/anchore/anchore-engine) for more project details.
+
+## Chart Details
+
+The chart is split into global and service specific configurations for the OSS Anchore Engine, as well as global and services specific configurations for the Enterprise components.
+
+  * The `anchoreGlobal` section is for configuration values required by all Anchore Engine components.
+  * The `anchoreEnterpriseGlobal` section is for configuration values required by all Anchore Engine Enterprise components.
+  * Service specific configuration values allow customization for each individual service.
+
+For a description of each component, view the official documentation at: [Anchore Enterprise Service Overview](https://docs.anchore.com/current/docs/overview/architecture/)
+
+## Installing the Anchore Engine Helm Chart
+TL;DR - `helm install stable/anchore-engine`
+
+Anchore Engine will take approximately 3 minutes to bootstrap. After the initial bootstrap period, Anchore Engine will begin a vulnerability feed sync. During this time, image analysis will show zero vulnerabilities until the sync is completed. This sync can take multiple hours depending on which feeds are enabled. The following anchore-cli command is available to poll the system and report back when the engine is bootstrapped and the vulnerability feeds are all synced up. `anchore-cli system wait`
+
+The recommended way to install the Anchore Engine Helm Chart is with a customized values file and a custom release name. It is highly recommended to set non-default passwords when deploying, all passwords are set to defaults specified in the chart. It is also recommended to utilize an external database, rather then using the included postgresql chart.
+
+Create a new file named `anchore_values.yaml` and add all desired custom values (examples below); then run the following command:
+
+  #### Helm v3 installation
+  `helm repo add stable https://kubernetes-charts.storage.googleapis.com`
+
+  `helm install <release_name> -f anchore_values.yaml stable/anchore-engine`
+
+##### Example anchore_values.yaml - using chart managed PostgreSQL service with custom passwords.
+*Note: Installs with chart managed PostgreSQL database. This is not a guaranteed production ready config.*
+```
+## anchore_values.yaml
+
+postgresql:
+  postgresPassword: <PASSWORD>
+  persistence:
+    size: 50Gi
+
+anchoreGlobal:
+  defaultAdminPassword: <PASSWORD>
+  defaultAdminEmail: <EMAIL>
+```
+
+## Adding Enterprise Components
+
+ The following features are available to Anchore Enterprise customers. Please contact the Anchore team for more information about getting a license for the enterprise features. [Anchore Enterprise Demo](https://anchore.com/demo/)
+
+    * Role based access control
+    * LDAP integration
+    * Graphical user interface
+    * Customizable UI dashboards
+    * On-premises feeds service
+    * Proprietary vulnerability data feed (vulnDB, MSRC)
+    * Anchore reporting API
+    * Notifications - Slack, GitHub, Jira, etc
+    * Microsoft image vulnerability scanning
+
+### Enabling Enterprise Services
+Enterprise services require an Anchore Enterprise license, as well as credentials with
+permission to the private docker repositories that contain the enterprise images.
+
+To use this Helm chart with the enterprise services enabled, perform these steps.
+
+1. Create a kubernetes secret containing your license file.
+
+    `kubectl create secret generic anchore-enterprise-license --from-file=license.yaml=<PATH/TO/LICENSE.YAML>`
+
+1. Create a kubernetes secret containing DockerHub credentials with access to the private anchore enterprise repositories.
+
+    `kubectl create secret docker-registry anchore-enterprise-pullcreds --docker-server=docker.io --docker-username=<DOCKERHUB_USER> --docker-password=<DOCKERHUB_PASSWORD> --docker-email=<EMAIL_ADDRESS>`
+
+1. (demo) Install the Helm chart using default values
+    #### Helm v3 installation
+    `helm repo add stable https://kubernetes-charts.storage.googleapis.com`
+
+    `helm install <release_name> --set anchoreEnterpriseGlobal.enabled=true stable/anchore-engine`
+
+2. (production) Install the Helm chart using a custom anchore_values.yaml file - *see examples below*
+    #### Helm v3 installation
+    `helm repo add stable https://kubernetes-charts.storage.googleapis.com`
+
+    `helm install <release_name> -f anchore_values.yaml stable/anchore-engine`
+
+#### Example anchore_values.yaml - installing Anchore Enterprise
+
+*Note: Installs with chart managed PostgreSQL & Redis databases. This is not a guaranteed production ready config.*
+```
+## anchore_values.yaml
+
+postgresql:
+  postgresPassword: <PASSWORD>
+  persistence:
+    size: 50Gi
+
+anchoreGlobal:
+  defaultAdminPassword: <PASSWORD>
+  defaultAdminEmail: <EMAIL>
+  enableMetrics: True
+
+anchoreEnterpriseGlobal:
+  enabled: True
+
+anchore-feeds-db:
+  postgresPassword: <PASSWORD>
+  persistence:
+    size: 20Gi
+
+anchore-ui-redis:
+  password: <PASSWORD>
+```
+
+## Installing on OpenShift
+As of chart version 1.3.1 deployments to OpenShift are fully supported. Due to permission constraints when utilizing OpenShift, the official RHEL postgresql image must be utilized, which requires custom environment variables to be configured for compatibility with this chart.
+
+#### Example anchore_values.yaml - deploying on OpenShift
+*Note: Installs with chart managed PostgreSQL database. This is not a guaranteed production ready config.*
+```
+## anchore_values.yaml
+
+postgresql:
+  image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+  imageTag: latest
+  extraEnv:
+  - name: POSTGRESQL_USER
+    value: anchoreengine
+  - name: POSTGRESQL_PASSWORD
+    value: anchore-postgres,123
+  - name: POSTGRESQL_DATABASE
+    value: anchore
+  - name: PGUSER
+    value: postgres
+  - name: LD_LIBRARY_PATH
+    value: /opt/rh/rh-postgresql96/root/usr/lib64
+  - name: PATH
+     value: /opt/rh/rh-postgresql96/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  postgresPassword: <PASSWORD>
+  persistence:
+    size: 50Gi
+
+anchoreGlobal:
+  defaultAdminPassword: <PASSWORD>
+  defaultAdminEmail: <EMAIL>
+  openShiftDeployment: True
+```
+
+To perform an Enterprise deployment on OpenShift use the following anchore_values.yaml configuration
+
+*Note: Installs with chart managed PostgreSQL database. This is not a guaranteed production ready config.*
+```
+## anchore_values.yaml
+
+postgresql:
+  image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+  imageTag: latest
+  extraEnv:
+  - name: POSTGRESQL_USER
+    value: anchoreengine
+  - name: POSTGRESQL_PASSWORD
+    value: anchore-postgres,123
+  - name: POSTGRESQL_DATABASE
+    value: anchore
+  - name: PGUSER
+    value: postgres
+  - name: LD_LIBRARY_PATH
+    value: /opt/rh/rh-postgresql96/root/usr/lib64
+  - name: PATH
+     value: /opt/rh/rh-postgresql96/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    postgresPassword: <PASSWORD>
+    persistence:
+      size: 20Gi
+
+anchoreGlobal:
+  defaultAdminPassword: <PASSWORD>
+  defaultAdminEmail: <EMAIL>
+  enableMetrics: True
+  openShiftDeployment: True
+
+anchoreEnterpriseGlobal:
+  enabled: True
+
+anchore-feeds-db:
+  image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+  imageTag: latest
+  extraEnv:
+  - name: POSTGRESQL_USER
+    value: anchoreengine
+  - name: POSTGRESQL_PASSWORD
+    value: anchore-postgres,123
+  - name: POSTGRESQL_DATABASE
+    value: anchore
+  - name: PGUSER
+    value: postgres
+  - name: LD_LIBRARY_PATH
+    value: /opt/rh/rh-postgresql96/root/usr/lib64
+  - name: PATH
+     value: /opt/rh/rh-postgresql96/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    postgresPassword: <PASSWORD>
+    persistence:
+      size: 50Gi
+
+anchore-ui-redis:
+  password: <PASSWORD>
+```
+# Chart Updates
+See the anchore-engine [CHANGELOG](https://github.com/anchore/anchore-engine/blob/master/CHANGELOG.md) for updates to anchore engine.
+
+## Upgrading from previous chart versions
+A Helm post-upgrade hook job has been added starting with Chart version 1.6.0 - this job will shut down all previously running Anchore services and perform the Anchore DB upgrade process using a kubernetes job. The upgrade will only be considered successful when this job completes successfully. Performing an update after v1.6.0 will cause the Helm client to block until the upgrade job completes and the new Anchore service pods are started. To view progress of the upgrade process, tail the logs of the upgrade jobs `anchore-engine-upgrade` and `anchore-enterprise-upgrade`. These job resources will be removed upon a successful helm upgrade.
+
+## Chart version 1.6.0
+Changes with this version include:
+  * Anchore database upgrades will now be handled using a helm post-upgrade hook job
+  * Anchore Engine image updated to v0.7.1
+  * Anchore Enterprise updated to v2.3.0 - see [CHANGELOG](https://docs.anchore.com/current/docs/releasenotes/230/)
+  * Enterprise deployments now use the `anchore/enterprise` image for all components
+  * Added GitHub advisory feeds
+  * Added NuGet .NET feeds to Enterprise feed service
+  * Updated resources to provide better minimum requirements baseline (these are still not production ready)
+
+## Chart version 1.5.0
+Changes to the Helm Chart include:
+  * Anchore Engine image updated to v0.7.0
+  * Enterprise deployments now use a different image for core anchore-engine services - .Values.anchoreEnterpriseGlobal.engineImage
+  * Default feed sync timeout increased to 180s
+  * Added a optional configuration for including imagePullSecret on all anchore-engine images - .Values.anchoreGlobal.imagePullSecretName
+
+## Chart version 1.4.0
+The following features were added with this chart version:
+  * Enterprise notifications service
+  * Numerous QOL improvements to the Enterprise UI service
+
+## Upgrading to Chart version 1.3.0
+The following features were added with this chart version:
+  * Allow custom CA certificates for TLS on all system dependencies (postgresql, ldap, registries)
+  * Customization of the analyzer configuration
+  * Improved authentication methods, allowing SAML/token based auth
+  * Enterprise UI reporting improvements
+  * Enterprise SSO integration
+  * Enterprise vulnerability data enhancement using VulnDB
+
+Internal Service SSL configuration has been changed to support a global certificate storage secret. When upgrading to v1.3.0 of the chart, make sure the values file is updated appropriately.
+
+#### Chart v1.3.0 internal service SSL configuration
+```
+anchoreGlobal:
+  certStoreSecretName: anchore-certs
+  internalServicesSsl:
+    enabled: true
+    verifyCerts: true
+    certSecretKeyName: anchore.example.com.key
+    certSecretCertName: anchore.example.com.crt
+```
+
+#### Chart v1.2.0 internal service SSL configuration
+```
+anchoreGlobal:
+  internalServicesSslEnabled: true
+  internalServicesSsl:
+    verifyCerts: true
+    certSecret: anchore-certs
+    certDir: /home/anchore/certs
+    certSecretKeyName: anchore.example.com.key
+    certSecretCertName: anchore.example.com.crt
+```
+
+## Upgrading to Chart version 1.0.0
+The following features were added with this chart version:
+  * Rootless UBI 7 base image
+  * Analyzer image layer caching
+  * Enterprise UI dashboards
+  * Enterprise LDAP integration
+  * Enterprise Reporting API
+
+Scratch volume configs for the analyzer component & the enterprise-feeds component have been moved to the anchoreGlobal section. Update your values.yaml file to reflect this change.
+
+#### Chart v0.13.0 scratch volume config
+```
+anchoreAnalyzer:
+  scratchVolume:
+      mountPath: /analysis_scratch
+      details:
+        # Specify volume configuration here
+        emptyDir: {}
+
+anchoreEnterpriseFeeds:
+  scratchVolume:
+    mountPath: /analysis_scratch
+    details:
+      # Specify volume configuration here
+      emptyDir: {}
+```
+
+#### Chart v1.0.0 scratch volume config
+```
+anchoreGlobal:
+  scratchVolume:
+    mountPath: /analysis_scratch
+    details:
+      # Specify volume configuration here
+      emptyDir: {}
+```
+
+## Upgrading to Chart version 0.12.0
+Redis dependency chart major version updated to v6.1.3 - check redis chart readme for instructions for upgrade.
+
+The ingress configuration has been consolidated to a single global section. This should make it easier to manage the ingress resource. Before performing an upgrade ensure you update your custom values file to reflect this change.
+
+#### Chart v0.12.0 ingress config
+```
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: gce
+  apiPath: /v1/*
+  uiPath: /*
+  apiHosts:
+  - anchore-api.example.com
+  uiHosts:
+  - anchore-ui.example.com
+```
+
+## Upgrading to Chart version 0.11.0
+The image map has been removed in all configuration sections in favor of individual keys. This should make configuration for tools like skaffold simpler. If using a custom values file, update your `image.repository`, `image.tag`, & `image.pullPolicy` values with `image` & `imagePullPolicy`.
+
+#### Chart v0.11.0 image config
+```
+anchoreGlobal:
+  image: docker.io/anchore/anchore-engine:v0.3.2
+  imagePullPolicy: IfNotPresent
+
+anchoreEnterpriseGlobal:
+  image: docker.io/anchore/enterprise:v0.3.3
+  imagePullPolicy: IfNotPresent
+
+anchoreEnterpriseUI:
+  image: docker.io/anchore/enterprise-ui:v0.3.1
+  imagePullPolicy: IfNotPresent
+```
+
+
+## Upgrading to Chart version 0.10.0
+
+Ingress resources have been changed to work natively with NGINX ingress controllers. If you're using a different ingress controller update your values.yaml file accordingly. See the __Using Ingress__ configuration section for examples of NGINX & GCE ingress controller configurations.
+
+Service configs have been moved from the anchoreGlobal section, to individual component sections in the values.yaml file. If you're upgrading from a previous install and are using custom ports or serviceTypes, be sure to update your values.yaml file accordingly.
+
+#### Chart v0.10.0 service config
+```
+anchoreApi:
+  service:
+    type: ClusterIP
+    port: 8228
+```
+
+## Upgrading to Chart version 0.9.0
+
+Version 0.9.0 of the anchore-engine helm chart includes major changes to the architecture, values.yaml file, as well as introduced Anchore Enterprise components. Due to these changes, it is highly recommended that upgrades are handled with caution. Any custom values.yaml files will also need to be adjusted to match the new structure. Version upgrades have only been validated when upgrading from 0.2.6 -> 0.9.0.
+
+`helm upgrade <release_name> stable/anchore-engine`
+
+When upgrading the Chart from version 0.2.6 to version 0.9.0, it will take approximately 5 minutes for anchore-engine to upgrade the database. To ensure that the upgrade has completed, run the `anchore-cli system status` command and verify the engine & db versions match the output below.
+
+```
+Engine DB Version: 0.0.8
+Engine Code Version: 0.3.0
+```
+
+# Configuration
+
+All configurations should be appended to your custom `anchore_values.yaml` file and utilized when installing the chart. While the configuration options of Anchore Engine are extensive, the options provided by the chart are:
+
+## Exposing the service outside the cluster:
+
+#### Using Ingress
+
+This configuration allows SSL termination using your chosen ingress controller.
+
+##### NGINX Ingress Controller
+```
+ingress:
+  enabled: true
+```
+
+##### ALB Ingress Controller
+```
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/scheme: internet-facing
+    apiPath: /v1/*
+    uiPath: /*
+    apiHosts:
+      - anchore-api.example.com
+    uiHosts:
+      - anchore-ui.example.com
+
+  anchoreApi:
+    service:
+      type: NodePort
+
+  anchoreEnterpriseUi:
+    service
+      type: NodePort
+```
+
+##### GCE Ingress Controller
+  ```
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: gce
+    apiPath: /v1/*
+    uiPath: /*
+    apiHosts:
+      - anchore-api.example.com
+    uiHosts:
+      - anchore-ui.example.com
+
+  anchoreApi:
+    service:
+      type: NodePort
+
+  anchoreEnterpriseUi:
+    service
+      type: NodePort
+  ```
+
+#### Using Service Type
+  ```
+  anchoreApi:
+    service:
+      type: LoadBalancer
+  ```
+
+### Utilize an Existing Secret
+Can be used to override the default secrets.yaml provided
+```
+anchoreGlobal:
+  existingSecret: "foo-bar"
+```
+
+### Install using an existing/external PostgreSQL instance
+*Note: it is recommended to use an external Postgresql instance for production installs*
+
+  ```
+  postgresql:
+    postgresPassword: <PASSWORD>
+    postgresUser: <USER>
+    postgresDatabase: <DATABASE>
+    enabled: false
+    externalEndpoint: <HOSTNAME:5432>
+
+  anchoreGlobal:
+    dbConfig:
+      ssl: true
+  ```
+
+### Install using Google CloudSQL
+  ```
+  ## anchore_values.yaml
+  postgresql:
+    enabled: false
+    postgresPassword: <CLOUDSQL-PASSWORD>
+    postgresUser: <CLOUDSQL-USER>
+    postgresDatabase: <CLOUDSQL-DATABASE>
+
+  cloudsql:
+    enabled: true
+    instance: "project:zone:cloudsqlinstancename"
+    # Optional existing service account secret to use.
+    useExistingServiceAcc: true
+    serviceAccSecretName: my_service_acc
+    serviceAccJsonName: for_cloudsql.json
+    image:
+      repository: gcr.io/cloudsql-docker/gce-proxy
+      tag: 1.12
+      pullPolicy: IfNotPresent
+  ```
+
+### Archive Driver
+*Note: it is recommended to use an external archive driver for production installs.*
+
+The archive subsystem of Anchore Engine is what stores large json documents and can consume quite a lot of storage if
+you analyze a lot of images. A general rule for storage provisioning is 10MB per image analyzed, so with thousands of
+analyzed images, you may need many gigabytes of storage. The Archive drivers now support other backends than just postgresql,
+so you can leverage external and scalable storage systems and keep the postgresql storage usage to a much lower level.
+
+##### Configuring Compression:
+
+The archive system has compression available to help reduce size of objects and storage consumed in exchange for slightly
+slower performance and more cpu usage. There are two config values:
+
+To toggle on/off (default is True), and set a minimum size for compression to be used (to avoid compressing things too small to be of much benefit, the default is 100):
+
+  ```
+  anchoreCatalog:
+    archive:
+      compression:
+        enabled=True
+        min_size_kbytes=100
+  ```
+
+##### The supported archive drivers are:
+
+* S3 - Any AWS s3-api compatible system (e.g. minio, scality, etc)
+* OpenStack Swift
+* Local FS - A local filesystem on the core pod. Does not handle sharding or replication, so generally only for testing.
+* DB - the default postgresql backend
+
+#### S3:
+  ```
+  anchoreCatalog:
+    archive:
+      storage_driver:
+        name: 's3'
+        config:
+          access_key: 'MY_ACCESS_KEY'
+          secret_key: 'MY_SECRET_KEY'
+          #iamauto: True
+          url: 'https://S3-end-point.example.com'
+          region: null
+          bucket: 'anchorearchive'
+          create_bucket: True
+      compression:
+      ... # Compression config here
+  ```
+
+#### Using Swift:
+
+The swift configuration is basically a pass-thru to the underlying pythonswiftclient so it can take quite a few different
+options depending on your swift deployment and config. The best way to configure the swift driver is by using a custom values.yaml
+
+The Swift driver supports three authentication methods:
+
+* Keystone V3
+* Keystone V2
+* Legacy (username / password)
+
+##### Keystone V3:
+  ```
+  anchoreCatalog:
+    archive:
+      storage_driver:
+        name: swift
+        config:
+          auth_version: '3'
+          os_username: 'myusername'
+          os_password: 'mypassword'
+          os_project_name: myproject
+          os_project_domain_name: example.com
+          os_auth_url: 'foo.example.com:8000/auth/etc'
+          container: 'anchorearchive'
+          # Optionally
+          create_container: True
+      compression:
+      ... # Compression config here
+  ```
+
+##### Keystone V2:
+  ```
+  anchoreCatalog:
+    archive:
+      storage_driver:    
+        name: swift
+        config:
+          auth_version: '2'
+          os_username: 'myusername'
+          os_password: 'mypassword'
+          os_tenant_name: 'mytenant'
+          os_auth_url: 'foo.example.com:8000/auth/etc'
+          container: 'anchorearchive'
+          # Optionally
+          create_container: True
+      compression:
+      ... # Compression config here
+  ```
+
+##### Legacy username/password:
+  ```
+  anchoreCatalog:
+    archive:
+      storage_driver:
+        name: swift
+        config:
+          user: 'user:password'
+          auth: 'http://swift.example.com:8080/auth/v1.0'
+          key:  'anchore'
+          container: 'anchorearchive'
+          # Optionally
+          create_container: True
+      compression:
+      ... # Compression config here
+  ```
+
+#### Postgresql:
+
+This is the default archive driver and requires no additional configuration.
+
+### Prometheus Metrics
+
+Anchore Engine supports exporting prometheus metrics form each container. To enable metrics:
+  ```
+  anchoreGlobal:
+    enableMetrics: True
+  ```
+
+When enabled, each service provides the metrics over the existing service port so your prometheus deployment will need to
+know about each pod and the ports it provides to scrape the metrics.
+
+### Using custom certificates
+A secret needs to be created in the same namespace as the anchore-engine chart installation. This secret should contain all custom certs, including CA certs & any certs used for internal TLS communication. 
+This secret will be mounted to all anchore-engine pods at /home/anchore/certs to be utilized by the system.
+
+### Event Notifications
+
+Anchore Engine in v0.2.3 introduces a new events subsystem that exposes system-wide events via both a REST api as well
+as via webhooks. The webhooks support filtering to ensure only certain event classes result in webhook calls to help limit
+the volume of calls if you desire. Events, and all webhooks, are emitted from the core components, so configuration is
+done in the coreConfig.
+
+To configure the events:
+  ```
+  anchoreCatalog:
+    events:
+      notification:
+        enabled:true
+      level=error
+  ```
+
+### Scaling Individual Components
+
+As of Chart version 0.9.0, all services can now be scaled-out by increasing the replica counts. The chart now supports
+this configuration.
+
+To set a specific number of service containers:
+  ```
+  anchoreAnalyzer:
+    replicaCount: 5
+
+  anchorePolicyEngine:
+    replicaCount: 3
+  ```
+
+To update the number in a running configuration:
+
+`helm upgrade --set anchoreAnalyzer.replicaCount=2 <releasename> stable/anchore-engine -f anchore_values.yaml`

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -19,7 +19,7 @@ The chart is split into global and service specific configurations for the OSS A
 For a description of each component, view the official documentation at: [Anchore Enterprise Service Overview](https://docs.anchore.com/current/docs/overview/architecture/)
 
 ## Installing the Anchore Engine Helm Chart
-TL;DR - `helm install stable/anchore-engine`
+TL;DR - `helm repo add anchore-charts https://charts.anchore.io && helm install anchore-charts/anchore-engine`
 
 Anchore Engine will take approximately 3 minutes to bootstrap. After the initial bootstrap period, Anchore Engine will begin a vulnerability feed sync. During this time, image analysis will show zero vulnerabilities until the sync is completed. This sync can take multiple hours depending on which feeds are enabled. The following anchore-cli command is available to poll the system and report back when the engine is bootstrapped and the vulnerability feeds are all synced up. `anchore-cli system wait`
 
@@ -28,9 +28,9 @@ The recommended way to install the Anchore Engine Helm Chart is with a customize
 Create a new file named `anchore_values.yaml` and add all desired custom values (examples below); then run the following command:
 
   #### Helm v3 installation
-  `helm repo add stable https://kubernetes-charts.storage.googleapis.com`
+  `helm repo add anchore-charts https://charts.anchore.io`
 
-  `helm install <release_name> -f anchore_values.yaml stable/anchore-engine`
+  `helm install <release_name> -f anchore_values.yaml anchore-charts/anchore-engine`
 
 ##### Example anchore_values.yaml - using chart managed PostgreSQL service with custom passwords.
 *Note: Installs with chart managed PostgreSQL database. This is not a guaranteed production ready config.*
@@ -77,15 +77,15 @@ To use this Helm chart with the enterprise services enabled, perform these steps
 
 1. (demo) Install the Helm chart using default values
     #### Helm v3 installation
-    `helm repo add stable https://kubernetes-charts.storage.googleapis.com`
+    `helm repo add anchore-charts https://charts.anchore.io`
 
-    `helm install <release_name> --set anchoreEnterpriseGlobal.enabled=true stable/anchore-engine`
+    `helm install <release_name> --set anchoreEnterpriseGlobal.enabled=true anchore-charts/anchore-engine`
 
 2. (production) Install the Helm chart using a custom anchore_values.yaml file - *see examples below*
     #### Helm v3 installation
-    `helm repo add stable https://kubernetes-charts.storage.googleapis.com`
+    `helm repo add anchore-charts https://charts.anchore.io`
 
-    `helm install <release_name> -f anchore_values.yaml stable/anchore-engine`
+    `helm install <release_name> -f anchore_values.yaml anchore-charts/anchore-engine`
 
 #### Example anchore_values.yaml - installing Anchore Enterprise
 
@@ -211,7 +211,7 @@ anchore-ui-redis:
 See the anchore-engine [CHANGELOG](https://github.com/anchore/anchore-engine/blob/master/CHANGELOG.md) for updates to anchore engine.
 
 ## Upgrading from previous chart versions
-A Helm post-upgrade hook job has been added starting with Chart version 1.6.0 - this job will shut down all previously running Anchore services and perform the Anchore DB upgrade process using a kubernetes job. The upgrade will only be considered successful when this job completes successfully. Performing an update after v1.6.0 will cause the Helm client to block until the upgrade job completes and the new Anchore service pods are started. To view progress of the upgrade process, tail the logs of the upgrade jobs `anchore-engine-upgrade` and `anchore-enterprise-upgrade`. These job resources will be removed upon a successful helm upgrade.
+A Helm post-upgrade hook job will shut down all previously running Anchore services and perform the Anchore DB upgrade process using a kubernetes job. The upgrade will only be considered successful when this job completes successfully. Performing an upgrade will cause the Helm client to block until the upgrade job completes and the new Anchore service pods are started. To view progress of the upgrade process, tail the logs of the upgrade jobs `anchore-engine-upgrade` and `anchore-enterprise-upgrade`. These job resources will be removed upon a successful helm upgrade.
 
 ## Chart version 1.7.0
 
@@ -430,163 +430,6 @@ Reconnect to the anchore-cli pod, or create another.  Then validate that you sti
 
 You are now running Anchore Enterprise from the new chart repository, with your data in place.
 
-## Chart version 1.6.0
-Changes with this version include:
-  * Anchore database upgrades will now be handled using a helm post-upgrade hook job
-  * Anchore Engine image updated to v0.7.1
-  * Anchore Enterprise updated to v2.3.0 - see [CHANGELOG](https://docs.anchore.com/current/docs/releasenotes/230/)
-  * Enterprise deployments now use the `anchore/enterprise` image for all components
-  * Added GitHub advisory feeds
-  * Added NuGet .NET feeds to Enterprise feed service
-  * Updated resources to provide better minimum requirements baseline (these are still not production ready)
-
-## Chart version 1.5.0
-Changes to the Helm Chart include:
-  * Anchore Engine image updated to v0.7.0
-  * Enterprise deployments now use a different image for core anchore-engine services - .Values.anchoreEnterpriseGlobal.engineImage
-  * Default feed sync timeout increased to 180s
-  * Added a optional configuration for including imagePullSecret on all anchore-engine images - .Values.anchoreGlobal.imagePullSecretName
-
-## Chart version 1.4.0
-The following features were added with this chart version:
-  * Enterprise notifications service
-  * Numerous QOL improvements to the Enterprise UI service
-
-## Upgrading to Chart version 1.3.0
-The following features were added with this chart version:
-  * Allow custom CA certificates for TLS on all system dependencies (postgresql, ldap, registries)
-  * Customization of the analyzer configuration
-  * Improved authentication methods, allowing SAML/token based auth
-  * Enterprise UI reporting improvements
-  * Enterprise SSO integration
-  * Enterprise vulnerability data enhancement using VulnDB
-
-Internal Service SSL configuration has been changed to support a global certificate storage secret. When upgrading to v1.3.0 of the chart, make sure the values file is updated appropriately.
-
-#### Chart v1.3.0 internal service SSL configuration
-```
-anchoreGlobal:
-  certStoreSecretName: anchore-certs
-  internalServicesSsl:
-    enabled: true
-    verifyCerts: true
-    certSecretKeyName: anchore.example.com.key
-    certSecretCertName: anchore.example.com.crt
-```
-
-#### Chart v1.2.0 internal service SSL configuration
-```
-anchoreGlobal:
-  internalServicesSslEnabled: true
-  internalServicesSsl:
-    verifyCerts: true
-    certSecret: anchore-certs
-    certDir: /home/anchore/certs
-    certSecretKeyName: anchore.example.com.key
-    certSecretCertName: anchore.example.com.crt
-```
-
-## Upgrading to Chart version 1.0.0
-The following features were added with this chart version:
-  * Rootless UBI 7 base image
-  * Analyzer image layer caching
-  * Enterprise UI dashboards
-  * Enterprise LDAP integration
-  * Enterprise Reporting API
-
-Scratch volume configs for the analyzer component & the enterprise-feeds component have been moved to the anchoreGlobal section. Update your values.yaml file to reflect this change.
-
-#### Chart v0.13.0 scratch volume config
-```
-anchoreAnalyzer:
-  scratchVolume:
-      mountPath: /analysis_scratch
-      details:
-        # Specify volume configuration here
-        emptyDir: {}
-
-anchoreEnterpriseFeeds:
-  scratchVolume:
-    mountPath: /analysis_scratch
-    details:
-      # Specify volume configuration here
-      emptyDir: {}
-```
-
-#### Chart v1.0.0 scratch volume config
-```
-anchoreGlobal:
-  scratchVolume:
-    mountPath: /analysis_scratch
-    details:
-      # Specify volume configuration here
-      emptyDir: {}
-```
-
-## Upgrading to Chart version 0.12.0
-Redis dependency chart major version updated to v6.1.3 - check redis chart readme for instructions for upgrade.
-
-The ingress configuration has been consolidated to a single global section. This should make it easier to manage the ingress resource. Before performing an upgrade ensure you update your custom values file to reflect this change.
-
-#### Chart v0.12.0 ingress config
-```
-ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: gce
-  apiPath: /v1/*
-  uiPath: /*
-  apiHosts:
-  - anchore-api.example.com
-  uiHosts:
-  - anchore-ui.example.com
-```
-
-## Upgrading to Chart version 0.11.0
-The image map has been removed in all configuration sections in favor of individual keys. This should make configuration for tools like skaffold simpler. If using a custom values file, update your `image.repository`, `image.tag`, & `image.pullPolicy` values with `image` & `imagePullPolicy`.
-
-#### Chart v0.11.0 image config
-```
-anchoreGlobal:
-  image: docker.io/anchore/anchore-engine:v0.3.2
-  imagePullPolicy: IfNotPresent
-
-anchoreEnterpriseGlobal:
-  image: docker.io/anchore/enterprise:v0.3.3
-  imagePullPolicy: IfNotPresent
-
-anchoreEnterpriseUI:
-  image: docker.io/anchore/enterprise-ui:v0.3.1
-  imagePullPolicy: IfNotPresent
-```
-
-
-## Upgrading to Chart version 0.10.0
-
-Ingress resources have been changed to work natively with NGINX ingress controllers. If you're using a different ingress controller update your values.yaml file accordingly. See the __Using Ingress__ configuration section for examples of NGINX & GCE ingress controller configurations.
-
-Service configs have been moved from the anchoreGlobal section, to individual component sections in the values.yaml file. If you're upgrading from a previous install and are using custom ports or serviceTypes, be sure to update your values.yaml file accordingly.
-
-#### Chart v0.10.0 service config
-```
-anchoreApi:
-  service:
-    type: ClusterIP
-    port: 8228
-```
-
-## Upgrading to Chart version 0.9.0
-
-Version 0.9.0 of the anchore-engine helm chart includes major changes to the architecture, values.yaml file, as well as introduced Anchore Enterprise components. Due to these changes, it is highly recommended that upgrades are handled with caution. Any custom values.yaml files will also need to be adjusted to match the new structure. Version upgrades have only been validated when upgrading from 0.2.6 -> 0.9.0.
-
-`helm upgrade <release_name> stable/anchore-engine`
-
-When upgrading the Chart from version 0.2.6 to version 0.9.0, it will take approximately 5 minutes for anchore-engine to upgrade the database. To ensure that the upgrade has completed, run the `anchore-cli system status` command and verify the engine & db versions match the output below.
-
-```
-Engine DB Version: 0.0.8
-Engine Code Version: 0.3.0
-```
 
 # Configuration
 
@@ -867,4 +710,4 @@ To set a specific number of service containers:
 
 To update the number in a running configuration:
 
-`helm upgrade --set anchoreAnalyzer.replicaCount=2 <releasename> stable/anchore-engine -f anchore_values.yaml`
+`helm upgrade --set anchoreAnalyzer.replicaCount=2 <releasename> anchore-charts/anchore-engine -f anchore_values.yaml`

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -19,7 +19,11 @@ The chart is split into global and service specific configurations for the OSS A
 For a description of each component, view the official documentation at: [Anchore Enterprise Service Overview](https://docs.anchore.com/current/docs/overview/architecture/)
 
 ## Installing the Anchore Engine Helm Chart
-TL;DR - `helm repo add anchore https://charts.anchore.io && helm install anchore/anchore-engine`
+### TL;DR
+```
+helm repo add anchore https://charts.anchore.io
+helm install my-release anchore/anchore-engine
+```
 
 Anchore Engine will take approximately 3 minutes to bootstrap. After the initial bootstrap period, Anchore Engine will begin a vulnerability feed sync. During this time, image analysis will show zero vulnerabilities until the sync is completed. This sync can take multiple hours depending on which feeds are enabled. The following anchore-cli command is available to poll the system and report back when the engine is bootstrapped and the vulnerability feeds are all synced up. `anchore-cli system wait`
 

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -280,7 +280,7 @@ The names of the PersistentVolumeClaims in the example shown are `my-anchore-anc
       $ helm uninstall --namespace=my-namespace my-anchore
       release "my-anchore" uninstalled
 
-Remove the Redis DB PersistentVolumeClaim, as another will be created when reinstalling:
+Anchore Enterprise users will want to remove the Redis DB PersistentVolumeClaim, as another will be created when reinstalling:
 
     $ kubectl delete pvc redis-data-my-anchore-anchore-ui-redis-master-0
 

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -228,11 +228,11 @@ These examples use Helm version 3 and kubectl client version 1.18, server versio
 
 #### ENSURE MIGRATION IS PERFORMED SEPARATELY FROM ANCHORE ENGINE UPGRADES
 
-All helm installation steps will include a flag to override the Anchore Engine/Enterprise images with your current running version. Record the version of your Anchore deployment and use it anytime the instructions refer to the Engine Code Version.
+All helm installation steps will include a flag to override the Anchore Engine/Enterprise images with your current running version. Upgrading your version of Anchore can be performed after moving to the new chart from charts.anchore.io. Record the version of your Anchore deployment and use it anytime the instructions refer to the Engine Code Version.
 
 ### Determine Currently Running Anchore Version
 
-Connect to the anchore-api pod and issue the following command and record the Engine Code Version:
+Connect to the anchore-api pod, issue the following command and record the Engine Code Version:
 
 ```
 [anchore@anchore-api anchore-engine]$ anchore-cli system status
@@ -357,7 +357,7 @@ To use Anchore Engine you need the URL, username, and password to access the API
 ...more instructions...
 ```
 
-Verify that your PersistentVolumeClaims are in place (output may vary):
+Verify that your PersistentVolumeClaims are bound (output may vary):
 
 ```
 $ kubectl get persistentvolumeclaim --namespace my-namespace
@@ -378,8 +378,8 @@ docker.io/ubuntu:latest                    sha256:60f560e52264ed1cb7829a0d59b1ee
 
 You are now running Anchore from the new chart repository, with your data in place. 
 
-#### Upgrade To Latest Version of Anchore
-Now you can upgrade Anchore to the latest version if desired.
+## Upgrade To Latest Version of Anchore
+Now that you're migrated to charts.anchore.io you can upgrade Anchore Engine to the latest version if desired.
 
 ```
 $ helm upgrade --namespace my-namespace -f anchore_values.yaml my-anchore anchore/anchore-engine

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -215,18 +215,17 @@ A Helm post-upgrade hook job will shut down all previously running Anchore servi
 
 ## Chart version 1.7.0
 
-
-### Migrating The Anchore Engine Chart To The New Anchore Charts Repository
+### Migrating To The New Anchore Charts Repository
 
 **FIXME write a nice overview paragraph here.**
 
 For these examples, we assume that your namespace is called `my-namespace` and your Anchore installation is called `my-anchore`.
 
-These examples use Helm version 3 and kubectl client version 1.18 and server version 1.14.
+These examples use Helm version 3 and kubectl client version 1.18, server version 1.14.
 
 #### Scan An Image For A Quick Validation Upon Reinstallation
 
-Scan an image to use as a quick validation of your data once you reinstall Anchore Engine (the command used to run an anchore-cli pod in your cluster may differ based on your namespace and installation names). You may wish to use a different image; we're using `alpine:latest`:
+Scan an image to use as a quick validation of your data once you reinstall Anchore (the command used to run an anchore-cli pod in your cluster may differ based on your namespace and installation names). You may wish to use a different image; we're using `alpine:latest`:
 
       $ kubectl run -i --tty anchore-cli --restart=Always --image anchore/engine-cli  --env ANCHORE_CLI_USER=admin --env ANCHORE_CLI_PASS=${ANCHORE_CLI_PASS} --env ANCHORE_CLI_URL=http://my-anchore-anchore-engine-legacy-api.my-namespace.svc.cluster.local:8228/v1/
       [anchore@anchore-cli anchore-cli]$ anchore-cli image add alpine:latest
@@ -255,7 +254,7 @@ Wait a short while, then:
       Last Eval: 2020-06-25T23:29:47Z
       Policy ID: 2c53a13c-1765-11e8-82ef-23527761d060
 
-Note the results to refer to later.
+Note the results for later reference - when reinstalling the chart, this image should still be in your installation. You may have other images scanned that you wish to use for validation.
 
 #### Determine Your Database PersistentVolumeClaim
 
@@ -267,18 +266,32 @@ Find the name of the database PersistentVolumeClaim using `kubectl`:
 
 The name of your PersistentVolumeClaim in the example shown is `my-anchore-postgresql`. Note that, as you will need it later.
 
+Anchore Enterprise users with a standalone Feeds Service will see a different set of PersistentVolumeClaims:
+
+      $ kubectl get persistentvolumeclaim --namespace my-namespace
+      NAME                                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+      my-anchore-anchore-feeds-db                    Bound    pvc-cd7ebb6f-bbe0-11ea-b9bf-42010a800020   20Gi       RWO            standard       3d
+      my-anchore-postgresql                          Bound    pvc-cd7dc7d2-bbe0-11ea-b9bf-42010a800020   20Gi       RWO            standard       3d
+
+The names of the PersistentVolumeClaims in the example shown are `my-anchore-anchore-feeds-db` and `my-anchore-postgresql`. You may see other persistent volume claims, but only `my-anchore-anchore-feeds-db` and `my-anchore-postgresql` are relevant for this migration; note the names, as you will need them later.
+
 #### Uninstall Your Anchore Installation With Helm
 
       $ helm uninstall --namespace=my-namespace my-anchore
       release "my-anchore" uninstalled
 
-Your PersistentVolumeClaim will still be resident in your cluster:
+Remove the Redis DB PersistentVolumeClaim, as another will be created when reinstalling:
+
+    $ kubectl delete pvc redis-data-my-anchore-anchore-ui-redis-master-0
+
+Your other PersistentVolumeClaims will still be resident in your cluster (we're showing results from an Anchore Enterprise installation that has a standalone Feeds Service below; Anchore Enterprise users without a standalone Feeds Service and Anchore Engine users will not see `my-anchore-anchore-feeds-db`):
 
       $ kubectl get persistentvolumeclaim --namespace my-namespace
-      NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-      my-anchore-postgresql   Bound    pvc-739f6f21-b73b-11ea-a2b9-42010a800176   20Gi       RWO            standard       2d
+      NAME                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+      my-anchore-anchore-feeds-db   Bound    pvc-a22abf70-bbb9-11ea-840b-42010a8001d8   20Gi       RWO            standard       3d
+      my-anchore-postgresql         Bound    pvc-e6daf90a-bbb8-11ea-840b-42010a8001d8   20Gi       RWO            standard       3d
 
-#### Add The New Anchore Helm Chart Repository And Install The Anchore Helm Chart
+#### Add The New Anchore Helm Chart Repository
 
       $ helm repo add anchore-charts https://charts.anchore.io
       "anchore-charts" has been added to your repositories
@@ -287,7 +300,9 @@ Your PersistentVolumeClaim will still be resident in your cluster:
       Hang tight while we grab the latest from your chart repositories...
       ...Successfully got an update from the "anchore-charts" chart repository
 
-This is where you'll need the name of the PersistentVolumeClaim from above, to override the value `postgresql.persistence.existingclaim`:
+#### Install The Anchore Helm Chart
+
+This is where you'll need the name of the PersistentVolumeClaim from above, to override the value `postgresql.persistence.existingclaim`. The helm command for Anchore Engine users is shown below:
 
       $ helm install --set postgresql.persistence.existingclaim=my-anchore-postgresql --namespace=my-namespace my-anchore anchore-charts/anchore-engine
       NAME: my-anchore
@@ -300,106 +315,7 @@ This is where you'll need the name of the PersistentVolumeClaim from above, to o
       To use Anchore Engine you need the URL, username, and password to access the API.
       ...more instructions...
 
-Verify that your PersistentVolumeClaim is in place:
-
-      $ kubectl get persistentvolumeclaim --namespace my-namespace
-      NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-      my-anchore-postgresql   Bound    pvc-739f6f21-b73b-11ea-a2b9-42010a800176   20Gi       RWO            standard       2d
-
-Reconnect to the anchore-cli pod, or create another.  Then validate that you still have the results from scanning `alpine:latest` (the "Last Eval" time will differ, as it's the time the evaluate command is run):
-
-      [anchore@anchore-cli anchore-cli]$ anchore-cli evaluate check alpine:latest
-      Image Digest: sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65
-      Full Tag: docker.io/alpine:latest
-      Status: pass
-      Last Eval: 2020-06-25T23:34:05Z
-      Policy ID: 2c53a13c-1765-11e8-82ef-23527761d060
-
-You are now running Anchore Engine from the new chart repository, with your data in place.
-
-
-### Migrating The Anchore Enterprise Chart To The New Anchore Charts Repository
-
-**FIXME write a nice overview paragraph here.**
-
-For these examples, we assume that your namespace is called `my-namespace` and your Anchore installation is called `my-anchore`.
-
-These examples use Helm version 3 and kubectl client version 1.18 and server version 1.14.
-
-#### Scan An Image For A Quick Validation Upon Reinstallation
-
-Scan an image to use as a quick validation of your data once you reinstall Anchore Engine (the command used to run an anchore-cli pod in your cluster may differ based on your namespace and installation names). You may wish to use a different image; we're using `alpine:latest`:
-
-      $ kubectl run -i --tty anchore-cli --restart=Always --image anchore/engine-cli  --env ANCHORE_CLI_USER=admin --env ANCHORE_CLI_PASS=${ANCHORE_CLI_PASS} --env ANCHORE_CLI_URL=http://my-anchore-anchore-engine-legacy-api.my-namespace.svc.cluster.local:8228/v1/
-      [anchore@anchore-cli anchore-cli]$ anchore-cli image add alpine:latest
-      Image Digest: sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65
-      Parent Digest: sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
-      Analysis Status: not_analyzed
-      Image Type: docker
-      Analyzed At: None
-      Image ID: a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e
-      Dockerfile Mode: None
-      Distro: None
-      Distro Version: None
-      Size: None
-      Architecture: None
-      Layer Count: None
-
-      Full Tag: docker.io/alpine:latest
-      Tag Detected At: 2020-06-25T23:28:49Z
-
-Wait a short while, then:
-
-      [anchore@anchore-cli anchore-cli]$ anchore-cli evaluate check alpine:latest
-      Image Digest: sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65
-      Full Tag: docker.io/alpine:latest
-      Status: pass
-      Last Eval: 2020-06-25T23:29:47Z
-      Policy ID: 2c53a13c-1765-11e8-82ef-23527761d060
-
-Note the results to refer to later.
-
-#### Determine Your Database PersistentVolumeClaim
-
-Find the names of the database PersistentVolumeClaims using `kubectl`:
-
-      $ kubectl get persistentvolumeclaim --namespace my-namespace
-      NAME                                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-      my-anchore-anchore-feeds-db                    Bound    pvc-cd7ebb6f-bbe0-11ea-b9bf-42010a800020   20Gi       RWO            standard       3d
-      my-anchore-postgresql                          Bound    pvc-cd7dc7d2-bbe0-11ea-b9bf-42010a800020   20Gi       RWO            standard       3d
-
-The names of the PersistentVolumeClaims in the example shown are `my-anchore-anchore-feeds-db` and `my-anchore-postgresql`, You may have other persistent volume clains, but only `my-anchore-anchore-feeds-db` and `my-anchore-postgresql` are relevant for this migration; note the names, as you will need them later.
-
-#### Uninstall Your Anchore Installation With Helm
-
-      $ helm uninstall --namespace=my-namespace my-anchore
-      release "my-anchore" uninstalled
-
-Remove the Redis DB PersistentVolumeClaim, as another will be created when reinstalling:
-
-    $ kubectl delete pvc redis-data-my-anchore-anchore-ui-redis-master-0
-
-Your other PersistentVolumeClaims will still be resident in your cluster:
-
-      $ kubectl get persistentvolumeclaim --namespace my-namespace
-      NAME                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-      my-anchore-anchore-feeds-db   Bound    pvc-a22abf70-bbb9-11ea-840b-42010a8001d8   20Gi       RWO            standard       3d
-      my-anchore-postgresql         Bound    pvc-e6daf90a-bbb8-11ea-840b-42010a8001d8   20Gi       RWO            standard       3d
-
-#### Add The New Anchore Helm Chart Repository And Install The Anchore Helm Chart
-
-      $ helm repo add anchore-charts https://charts.anchore.io
-      "anchore-charts" has been added to your repositories
-
-      $ helm repo update
-      Hang tight while we grab the latest from your chart repositories...
-      ...Successfully got an update from the "anchore-charts" chart repository
-
-This is where you'll need the name of the PersistentVolumeClaims from above, to set the values `postgresql.persistence.existingclaim` and `anchore-feeds-db.persistence.existingclaim`.  Note that in the helm command, we're including a simple values file to enable Anchore Enterprise:
-
-      $ cat enterprise_values.yaml
-      anchoreEnterpriseGlobal:
-        enabled: true
+The helm command for Anchore Enterprise users (this command includes specifying the existing persistence claim for the Feeds Service):
 
       $ helm install --set postgresql.persistence.existingclaim=my-anchore-postgresql,anchore-feeds-db.persistence.existingclaim=my-anchore-anchore-feeds-db --namespace=my-namespace my-anchore -f enterprise_values.yaml new-repo-name/anchore-engine
       NAME: my-anchore
@@ -412,7 +328,7 @@ This is where you'll need the name of the PersistentVolumeClaims from above, to 
       To use Anchore Engine you need the URL, username, and password to access the API.
       ...more instructions...
 
-Your PersistentVolumeClaims are in place:
+Verify that your PersistentVolumeClaims are in place (output may vary):
 
       $ kubectl get persistentvolumeclaim --namespace my-namespace
       NAME                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
@@ -428,7 +344,7 @@ Reconnect to the anchore-cli pod, or create another.  Then validate that you sti
       Last Eval: 2020-06-25T23:34:05Z
       Policy ID: 2c53a13c-1765-11e8-82ef-23527761d060
 
-You are now running Anchore Enterprise from the new chart repository, with your data in place.
+You are now running Anchore from the new chart repository, with your data in place.
 
 
 # Configuration

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -289,7 +289,7 @@ $ helm uninstall --namespace=my-namespace my-anchore
 release "my-anchore" uninstalled
 ```
 
-Anchore Enterprise users will want to remove the Redis DB PersistentVolumeClaim, this will delete all current session data but will not effect stability of the deployment:
+Anchore Enterprise users will want to remove the Redis DB PersistentVolumeClaim; this will delete all current session data but will not affect stability of the deployment:
 
 ```
 $ kubectl delete pvc redis-data-my-anchore-anchore-ui-redis-master-0
@@ -317,7 +317,7 @@ Hang tight while we grab the latest from your chart repositories...
 
 #### Install The Anchore Helm Chart
 
-This is where you'll need the name of the PersistentVolumeClaim from above, to override the value `postgresql.persistence.existingclaim`. Update your anchore_values.yaml file as shown below:
+Update your anchore_values.yaml file as shown, using the PersistentVolumeClaim values from above:
 
 Engine only deployment values file example:
 ```

--- a/stable/anchore-engine/charts/postgresql/Chart.yaml
+++ b/stable/anchore-engine/charts/postgresql/Chart.yaml
@@ -1,0 +1,16 @@
+appVersion: 9.6.18
+description: Object-relational database management system (ORDBMS) with an emphasis
+  on extensibility and on standards-compliance.
+engine: gotpl
+home: https://www.postgresql.org/
+icon: https://www.postgresql.org/media/img/about/press/elephant.png
+keywords:
+- postgresql
+- postgres
+- database
+- sql
+name: postgresql
+sources:
+- https://github.com/kubernetes/charts
+- https://github.com/docker-library/postgres
+version: 1.0.1

--- a/stable/anchore-engine/charts/postgresql/README.md
+++ b/stable/anchore-engine/charts/postgresql/README.md
@@ -1,0 +1,157 @@
+# PostgreSQL
+
+[PostgreSQL](https://postgresql.org) is a powerful, open source object-relational database system. It has more than 15 years of active development and a proven architecture that has earned it a strong reputation for reliability, data integrity, and correctness.
+
+## TL;DR;
+
+```bash
+$ helm install stable/postgresql
+```
+
+## Introduction
+
+This chart bootstraps a [PostgreSQL](https://github.com/docker-library/postgres) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure (Only when persisting data)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/postgresql
+```
+
+The command deploys PostgreSQL on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the PostgreSQL chart and their default values.
+
+| Parameter                  | Description                                     | Default                                                    |
+| -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
+| `image`                    | `postgres` image repository                     | `postgres`                                                 |
+| `imageTag`                 | `postgres` image tag                            | `9.6.2`                                                    |
+| `imagePullPolicy`          | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `imagePullSecrets`         | Image pull secrets                              | `nil`                                                      |
+| `postgresUser`             | Username of new user to create.                 | `postgres`                                                 |
+| `postgresPassword`         | Password for the new user.                      | random 10 characters                                       |
+| `usePasswordFile`          | Inject the password via file instead of env var | `false`                                                    |
+| `postgresDatabase`         | Name for new database to create.                | `postgres`                                                 |
+| `postgresInitdbArgs`       | Initdb Arguments                                | `nil`                                                      |
+| `schedulerName`            | Name of an alternate scheduler                  | `nil`                                                      |
+| `existingSecret`           | Use Existing secret for Admin password          | `nil`                                                      |
+| `postgresConfig`           | Runtime Config Parameters                       | `nil`                                                      |
+| `pgHbaConf`                | Content of pg\_hba.conf                         | `nil (do not create pg_hba.conf)`                          |
+| `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
+| `persistence.existingClaim`| Provide an existing PersistentVolumeClaim       | `nil`                                                      |
+| `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
+| `persistence.annotations`  | Persistent Volume annotations                   | `{}`                                                       |
+| `persistence.size`         | Size of data volume                             | `8Gi`                                                      |
+| `persistence.subPath`      | Subdirectory of the volume to mount at          | `postgresql-db`                                            |
+| `persistence.mountPath`    | Mount path of data volume                       | `/var/lib/postgresql/data/pgdata`                          |
+| `persistence.resourcePolicy` | set resource-policy Helm annotation on PVC. Can be nil or "keep" | `nil`                                   |
+| `resources`                | CPU/Memory resource requests/limits             | Memory: `256Mi`, CPU: `100m`                               |
+| `metrics.enabled`          | Start a side-car prometheus exporter            | `false`                                                    |
+| `metrics.image`            | Exporter image                                  | `wrouesnel/postgres_exporter`                              |
+| `metrics.imageTag`         | Exporter image                                  | `v0.1.1`                                                   |
+| `metrics.imagePullPolicy`  | Exporter image pull policy                      | `IfNotPresent`                                             |
+| `metrics.resources`        | Exporter resource requests/limit                | Memory: `256Mi`, CPU: `100m`                               |
+| `metrics.customMetrics`    | Additional custom metrics                       | `nil`                                                      |
+| `service.externalIPs`      | External IPs to listen on                       | `[]`                                                       |
+| `service.port`             | TCP port                                        | `5432`                                                     |
+| `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
+| `service.nodePort`         | NodePort value if service.type is `NodePort`    | `nil`                                                      |
+| `networkPolicy.enabled`    | Enable NetworkPolicy                            | `false`                                                    |
+| `networkPolicy.allowExternal` | Don't require client label for connections   | `true`                                                     |
+| `nodeSelector`             | Node labels for pod assignment                  | {}                                                         |
+| `affinity`                 | Affinity settings for pod assignment            | {}                                                         |
+| `tolerations`              | Toleration labels for pod assignment            | []                                                         |
+| `terminationGracePeriodSeconds`     | Optional duration in seconds the pod needs to terminate gracefully | `nil`                          |
+| `probes.liveness.initialDelay`      | Liveness probe initial delay           | `60`                                                       |
+| `probes.liveness.timeoutSeconds`    | Liveness probe timeout seconds         | `5`                                                        |
+| `probes.liveness.failureThreshold`  | Liveness probe failure threshold       | `6`                                                        |
+| `probes.readiness.initialDelay`     | Readiness probe initial delay          | `5`                                                        |
+| `probes.readiness.timeoutSeconds`   | Readiness probe timeout seconds        | `3`                                                        |
+| `probes.readiness.failureThreshold` | Readiness probe failure threshold      | `5`                                                        |
+| `podAnnotations`           | Annotations for the postgresql pod              | {}                                                         |
+| `deploymentAnnotations`    | Annotations for the postgresql deployment       | {}                                                         |
+| `extraEnv`                 | Any extra environment variables you would like to pass on to the pod | {}                                    |
+
+The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set postgresUser=my-user,postgresPassword=secretpassword,postgresDatabase=my-database \
+    stable/postgresql
+```
+
+The above command creates a PostgreSQL user named `my-user` with password `secretpassword`. Additionally it creates a database named `my-database`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/postgresql
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [postgres](https://github.com/docker-library/postgres) image stores the PostgreSQL data and configurations at the `/var/lib/postgresql/data/pgdata` path of the container.
+
+The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning. If the PersistentVolumeClaim should not be managed by the chart, define `persistence.existingClaim`.
+
+Note: When using persistence ensure that you either provide a `postgresPassword` or use `existingSecret`, otherwise `helm update` will generate a new random password which is ignored by postgres. That will cause confusing behaviour especially if services depend on the secret
+
+### Existing PersistentVolumeClaims
+
+1. Create the PersistentVolume
+1. Create the PersistentVolumeClaim
+1. Install the chart
+```bash
+$ helm install --set persistence.existingClaim=PVC_NAME postgresql
+```
+
+The volume defaults to mount at a subdirectory of the volume instead of the volume root to avoid the volume's hidden directories from interfering with `initdb`.  If you are upgrading this chart from before version `0.4.0`, set `persistence.subPath` to `""`.
+
+## Metrics
+The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9187) is not exposed and it is expected that the metrics are collected from inside the k8s cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml).
+
+The exporter allows to create custom metrics from additional SQL queries. See the Chart's `values.yaml` for an example and consult the [exporters documentation](https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file) for more details.
+
+## NetworkPolicy
+
+To enable network policy for PostgreSQL,
+install [a networking plugin that implements the Kubernetes
+NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin),
+and set `networkPolicy.enabled` to `true`.
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
+the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
+
+    kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+
+With NetworkPolicy enabled, traffic will be limited to just port 5432.
+
+For more precise policy, set `networkPolicy.allowExternal=false`. This will
+only allow pods with the generated client label to connect to PostgreSQL.
+This label will be displayed in the output of a successful install.

--- a/stable/anchore-engine/charts/postgresql/templates/NOTES.txt
+++ b/stable/anchore-engine/charts/postgresql/templates/NOTES.txt
@@ -1,0 +1,41 @@
+PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
+{{ template "postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+{{- if .Values.existingSecret }}
+If you have not already created the postgres admin secret:
+
+   kubectl create secret generic {{ .Values.existingSecret }} --namespace {{ .Release.Namespace }} --from-file=./postgres-password
+{{ else }}
+To get your user password run:
+
+    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)
+{{- end }}
+
+To connect to your database run the following command (using the env variable from above):
+
+   kubectl run --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }}-client --restart=Never --rm --tty -i --image postgres \
+   --env "PGPASSWORD=$PGPASSWORD" \{{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+   --labels="{{ template "postgresql.fullname" . }}-client=true" \{{- end }}
+   --command -- psql -U {{ default "postgres" .Values.postgresUser }} \
+   -h {{ template "postgresql.fullname" . }} {{ default "postgres" .Values.postgresDatabase }}
+
+{{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+Note: Since NetworkPolicy is enabled, only pods with label
+{{ template "postgresql.fullname" . }}-client=true"
+will be able to connect to this PostgreSQL cluster.
+{{- end }}
+
+To connect to your database directly from outside the K8s cluster:
+   {{- if contains "NodePort" .Values.service.type }}
+     PGHOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+     PGPORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "ClusterIP" .Values.service.type }}
+     PGHOST=127.0.0.1
+     PGPORT={{ default "5432" .Values.service.port }}
+
+     # Execute the following commands to route the connection:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "postgresql.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ default "5432" .Values.service.port }}:{{ default "5432" .Values.service.port }}
+
+   {{- end }}

--- a/stable/anchore-engine/charts/postgresql/templates/_helpers.tpl
+++ b/stable/anchore-engine/charts/postgresql/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "postgresql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "postgresql.networkPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+"extensions/v1beta1"
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "postgresql.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "postgresql.secretName" -}}
+{{ default (include "postgresql.fullname" .) .Values.existingSecret }}
+{{- end -}}

--- a/stable/anchore-engine/charts/postgresql/templates/configmap.yaml
+++ b/stable/anchore-engine/charts/postgresql/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- if .Values.metrics.customMetrics }}
+  custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | quote }}
+  {{- end }}
+  {{- if .Values.pgHbaConf }}
+  pg_hba.conf: {{ .Values.pgHbaConf | quote }}
+  {{- end }}

--- a/stable/anchore-engine/charts/postgresql/templates/deployment.yaml
+++ b/stable/anchore-engine/charts/postgresql/templates/deployment.yaml
@@ -1,0 +1,196 @@
+apiVersion: {{- if .Capabilities.APIVersions.Has "apps/v1" }} apps/v1 {{- else }} extensions/v1beta1 {{- end }}
+kind: Deployment
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.strategy }}
+  strategy:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "postgresql.name" . }}
+      release: {{ .Release.Name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ template "postgresql.name" . }}
+        release: {{ .Release.Name }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+      containers:
+      - name: {{ template "postgresql.fullname" . }}
+        image: "{{ .Values.image }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        args:
+          {{- range $key, $value := default dict .Values.postgresConfig }}
+          - -c
+          - '{{ $key | snakecase }}={{ $value }}'
+          {{- end }}
+          {{- if .Values.pgHbaConf }}
+          - -c
+          - hba_file=/pg_hba/pg_hba.conf
+          {{- end }}
+        env:
+        - name: POSTGRES_USER
+          value: {{ default "postgres" .Values.postgresUser | quote }}
+          # Required for pg_isready in the health probes.
+        - name: PGUSER
+          value: {{ default "postgres" .Values.postgresUser | quote }}
+        - name: POSTGRES_DB
+          value: {{ default "" .Values.postgresDatabase | quote }}
+        - name: POSTGRES_INITDB_ARGS
+          value: {{ default "" .Values.postgresInitdbArgs | quote }}
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        {{- if .Values.usePasswordFile }}
+        - name: POSTGRES_PASSWORD_FILE
+          value: /conf/postgres-password
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "postgresql.secretName" . }}
+              key: postgres-password
+        {{- end }}
+        - name: POD_IP
+          valueFrom: { fieldRef: { fieldPath: status.podIP } }
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+{{- end }}
+        ports:
+        - name: postgresql
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: {{ .Values.probes.liveness.initialDelay }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: {{ .Values.probes.readiness.initialDelay }}
+          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: {{ .Values.persistence.mountPath }}
+          subPath: {{ .Values.persistence.subPath }}
+        {{- if .Values.usePasswordFile }}
+        - name: password-file
+          mountPath: /conf
+          readOnly: true
+        {{- end }}
+        {{- if .Values.pgHbaConf }}
+        - name: pg-hba-conf
+          mountPath: /pg_hba
+          readOnly: true
+        {{- end }}
+{{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
+        imagePullPolicy: {{ default "" .Values.metrics.imagePullPolicy | quote }}
+        env:
+        - name: DATA_SOURCE_NAME
+          value: postgresql://{{ default "postgres" .Values.postgresUser }}@127.0.0.1:5432?sslmode=disable
+        {{- if .Values.metrics.customMetrics }}
+        - name: PG_EXPORTER_EXTEND_QUERY_PATH
+          value: /conf/custom-metrics.yaml
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: 9187
+        {{- if .Values.metrics.customMetrics }}
+        volumeMounts:
+          - name: custom-metrics
+            mountPath: /conf
+            readOnly: true
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+{{- end }}
+      volumes:
+      - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "postgresql.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
+      - name: custom-metrics
+        configMap:
+          name: {{ template "postgresql.fullname" . }}
+          items:
+            - key: custom-metrics.yaml
+              path: custom-metrics.yaml
+      {{- end }}
+      {{- if .Values.usePasswordFile }}
+      - name: password-file
+        secret:
+          secretName: {{ template "postgresql.secretName" . }}
+          items:
+            - key: postgres-password
+              path: postgres-password
+      {{- end }}
+      {{- if .Values.pgHbaConf }}
+      - name: pg-hba-conf
+        configMap:
+          name: {{ template "postgresql.fullname" . }}
+          items:
+            - key: pg_hba.conf
+              path: pg_hba.conf
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecrets }}
+      {{- end }}

--- a/stable/anchore-engine/charts/postgresql/templates/networkpolicy.yaml
+++ b/stable/anchore-engine/charts/postgresql/templates/networkpolicy.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ template "postgresql.networkPolicy.apiVersion" . }}
+metadata:
+  name: "{{ template "postgresql.fullname" . }}"
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "postgresql.name" . }}
+      release: {{ .Release.Name }}
+  ingress:
+    # Allow inbound connections
+    - ports:
+      - port: 5432
+    {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+      - podSelector:
+          matchLabels:
+            {{ template "postgresql.fullname" . }}-client: "true"
+    {{- end }}
+    # Allow prometheus scrapes
+    - ports:
+      - port: 9187
+{{- end }}

--- a/stable/anchore-engine/charts/postgresql/templates/pvc.yaml
+++ b/stable/anchore-engine/charts/postgresql/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/resource-policy": {{ default "" .Values.persistence.resourcePolicy }}
+{{- if .Values.persistence.annotations }}
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/stable/anchore-engine/charts/postgresql/templates/secrets.yaml
+++ b/stable/anchore-engine/charts/postgresql/templates/secrets.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ if .Values.postgresPassword }}
+  postgres-password:  {{ .Values.postgresPassword | b64enc | quote }}
+  {{ else }}
+  postgres-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+{{- end }}

--- a/stable/anchore-engine/charts/postgresql/templates/svc.yaml
+++ b/stable/anchore-engine/charts/postgresql/templates/svc.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.metrics.enabled }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9187"
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: 9187
+    targetPort: metrics
+  {{- end }}
+  - name: postgresql
+    port: {{ .Values.service.port }}
+    targetPort: postgresql
+  {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+  {{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    app: {{ template "postgresql.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/anchore-engine/charts/postgresql/values.yaml
+++ b/stable/anchore-engine/charts/postgresql/values.yaml
@@ -1,0 +1,160 @@
+## postgres image
+image: postgres:9.6.18
+
+## Specify a imagePullPolicy
+## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
+## Specify imagePullSecrets
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+##
+# imagePullSecrets: myregistrykey
+
+## Create a database user
+## Default: postgres
+# postgresUser:
+## Default: random 10 character string
+# postgresPassword:
+
+## Inject postgresPassword via a volume mount instead of environment variable
+usePasswordFile: false
+
+## Use Existing secret instead of creating one
+## It must have a postgres-password key containing the desired password
+# existingSecret: 'secret'
+
+## Create a database
+## Default: the postgres user
+# postgresDatabase:
+
+## Specify initdb arguments, e.g. --data-checksums
+## ref: https://github.com/docker-library/docs/blob/master/postgres/content.md#postgres_initdb_args
+## ref: https://www.postgresql.org/docs/current/static/app-initdb.html
+# postgresInitdbArgs:
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## Optional duration in seconds the pod needs to terminate gracefully.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+##
+# terminationGracePeriodSeconds: 30
+
+## Specify runtime config parameters as a dict, using camelCase, e.g.
+## {"sharedBuffers": "500MB"}
+## ref: https://www.postgresql.org/docs/current/static/runtime-config.html
+# postgresConfig:
+
+## Specify content for pg_hba.conf
+## Default: do not create pg_hba.conf
+# pgHbaConf: |-
+#   local all all trust
+#   host all all localhost trust
+#   host mydatabase mysuser 192.168.0.0/24 md5
+
+## Persist data to a persistent volume
+persistence:
+  enabled: true
+  resourcePolicy:  # set resource-policy Helm annotation on PVC. Can be nil or "keep"
+
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
+  ## database data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 8Gi
+  subPath: "postgresql-db"
+  mountPath: /var/lib/postgresql/data/pgdata
+
+  # annotations: {}
+
+metrics:
+  enabled: false
+  image: wrouesnel/postgres_exporter
+  imageTag: v0.4.6
+  imagePullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+    ## Define additional custom metrics
+    ## ref: https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file
+    # customMetrics:
+    #   pg_database:
+    #     query: "SELECT d.datname AS name, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
+    #     metrics:
+    #       - name:
+    #           usage: "LABEL"
+    #           description: "Name of the database"
+    #       - size_bytes:
+    #           usage: "GAUGE"
+    #           description: "Size of the database in bytes"
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m
+
+service:
+  type: ClusterIP
+  port: 5432
+  externalIPs: []
+  ## Manually set NodePort value
+  ## Requires service.type: NodePort
+  # nodePort:
+
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources.
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port PostgreSQL is listening
+  ## on. When true, PostgreSQL will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+
+## Node labels and tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Override default liveness & readiness probes
+probes:
+  liveness:
+    initialDelay: 60
+    timeoutSeconds: 5
+    failureThreshold: 6
+  readiness:
+    initialDelay: 5
+    timeoutSeconds: 3
+    periodSeconds: 5
+## Annotations for the deployment and nodes.
+deploymentAnnotations: {}
+podAnnotations: {}
+
+## Deployment pods replace strategy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+# strategy: {}
+
+# Define custom environment variables to pass to the image here
+extraEnv: {}

--- a/stable/anchore-engine/enterprise_values.yaml
+++ b/stable/anchore-engine/enterprise_values.yaml
@@ -1,0 +1,4 @@
+anchoreEnterpriseGlobal:
+  enabled: true
+
+

--- a/stable/anchore-engine/requirements.lock
+++ b/stable/anchore-engine/requirements.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 1.0.0
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 1.0.0
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 6.4.5
+digest: sha256:468485c2a122e03e69f112be6e0fe631f048124ce96fb0548138d64eef46b16b
+generated: 2019-05-06T16:49:00.766734-07:00

--- a/stable/anchore-engine/requirements.lock
+++ b/stable/anchore-engine/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.0.0
+  repository: ""
+  version: 1.0.1
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.0.0
+  repository: ""
+  version: 1.0.1
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 6.4.5
-digest: sha256:468485c2a122e03e69f112be6e0fe631f048124ce96fb0548138d64eef46b16b
-generated: 2019-05-06T16:49:00.766734-07:00
+  repository: https://charts.bitnami.com/bitnami
+  version: "10"
+digest: sha256:c058c785a30ae74b41d3459e0cb91e740a670af06199899342e22426b98cda4f
+generated: "2020-07-08T15:52:50.256837-07:00"

--- a/stable/anchore-engine/requirements.yaml
+++ b/stable/anchore-engine/requirements.yaml
@@ -1,0 +1,17 @@
+dependencies:
+  - name: postgresql
+    version: "1.0.0"
+    repository: "alias:stable"
+    condition: postgresql.enabled
+
+  - name: postgresql
+    version: "1.0.0"
+    repository: "alias:stable"
+    condition: anchore-feeds-db.enabled,anchoreEnterpriseGlobal.enabled
+    alias: anchore-feeds-db
+
+  - name: redis
+    version: "6"
+    repository: "alias:stable"
+    condition: anchore-ui-redis.enabled,anchoreEnterpriseGlobal.enabled
+    alias: anchore-ui-redis

--- a/stable/anchore-engine/requirements.yaml
+++ b/stable/anchore-engine/requirements.yaml
@@ -1,17 +1,15 @@
 dependencies:
   - name: postgresql
-    version: "1.0.0"
-    repository: "alias:stable"
+    version: "1.0.1"
     condition: postgresql.enabled
 
   - name: postgresql
-    version: "1.0.0"
-    repository: "alias:stable"
+    version: "1.0.1"
     condition: anchore-feeds-db.enabled,anchoreEnterpriseGlobal.enabled
     alias: anchore-feeds-db
 
   - name: redis
-    version: "6"
-    repository: "alias:stable"
+    version: "10"
+    repository: "https://charts.bitnami.com/bitnami"
     condition: anchore-ui-redis.enabled,anchoreEnterpriseGlobal.enabled
     alias: anchore-ui-redis

--- a/stable/anchore-engine/templates/NOTES.txt
+++ b/stable/anchore-engine/templates/NOTES.txt
@@ -1,0 +1,61 @@
+To use Anchore Engine you need the URL, username, and password to access the API.
+
+Anchore Engine can be accessed via port {{ .Values.anchoreApi.service.port }} on the following DNS name from within the cluster:
+{{ template "anchore-engine.api.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+Here are the steps to configure the anchore-cli (`pip install anchorecli`). Use these same values for direct API access as well.
+
+To configure your anchore-cli run:
+
+    ANCHORE_CLI_USER=admin
+    ANCHORE_CLI_PASS=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "anchore-engine.fullname" . }} -o jsonpath="{.data.ANCHORE_ADMIN_PASSWORD}" | base64 --decode; echo)
+{{ if .Values.ingress.enabled }}
+   ANCHORE_CLI_URL={{- if .Values.anchoreGlobal.internalServicesSsl.enabled -}}https{{- else }}http{{- end -}}://$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ template "anchore-engine.fullname" . }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")/v1/
+{{ else }}
+Using the service endpoint from within the cluster you can use:
+    ANCHORE_CLI_URL={{- if .Values.anchoreGlobal.internalServicesSsl.enabled -}}https{{- else }}http{{- end -}}://{{ template "anchore-engine.api.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.anchoreApi.service.port}}/v1/
+{{ end }}
+
+To verify the service is up and running, you can run container for the Anchore Engine CLI:
+
+    kubectl run -i --tty anchore-cli --restart=Always --image anchore/engine-cli {{ if and (not .Values.anchoreGlobal.internalServicesSsl.verifyCerts) .Values.anchoreGlobal.internalServicesSsl.enabled -}}--env ANCHORE_CLI_SSL_VERIFY=n{{- end }} --env ANCHORE_CLI_USER=admin --env ANCHORE_CLI_PASS=${ANCHORE_CLI_PASS} --env ANCHORE_CLI_URL=http://{{ template "anchore-engine.api.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.anchoreApi.service.port}}/v1/
+
+from within the container you can use 'anchore-cli' commands.
+
+* NOTE: On first startup of anchore-engine, it performs a CVE data sync which may take several minutes to complete. During this time the system status will report 'partially_down' and any images added for analysis will stay in the 'not_analyzed' state.
+Once the sync is complete, any queued images will be analyzed and the system status will change to 'all_up'.
+
+Initial setup time can be >120sec for postgresql setup and readiness checks to pass for the services as indicated by pod state. You can check with:
+    kubectl get pods -l app={{ template "anchore-engine.fullname" .}},component=api
+
+
+A quick primer on using the Anchore Engine CLI follows. For more info see: https://github.com/anchore/anchore-engine/wiki/Getting-Started
+
+View system status:
+
+    anchore-cli system status
+
+Add an image to be analyzed:
+
+    anchore-cli image add <imageref>
+
+List images and see the analysis status (not_analyzed initially):
+
+    anchore-cli image list
+
+Once the image is analyzed you'll see status change to 'analyzed'. This may take some time on first execution with a new database because
+the system must first do a CVE data sync which can take several minutes. Once complete, the image will transition to 'analyzing' state.
+
+When the image reaches 'analyzed' state, you can view policy evaluation output with:
+
+    anchore-cli evaluate check <imageref>
+
+List CVEs found in the image with:
+
+    anchore-cli image vuln <imageref> os
+
+List OS packages found in the image with:
+    anchore-cli image content <imageref> os
+
+List files found in the image with:
+    anchore-cli image content <imageref> files

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -1,0 +1,141 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.analyzer.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "analyzer"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.catalog.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "catalog"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.api.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "api"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.policy-engine.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "policy"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.simplequeue.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "simplequeue"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.enterprise.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "enterprise"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.enterprise-ui.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "enterprise-ui"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.enterprise-feeds.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "enterprise-feeds"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.enterprise-reports.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "enterprise-reports"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "anchore-engine.enterprise-notifications.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "enterprise-notifications"| trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified dependency name for the db.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgres.fullname" -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified dependency name for the feeds db.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgres.anchore-feeds-db.fullname" -}}
+{{- printf "%s-%s" .Release.Name "anchore-feeds-db" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified dependency name for the db.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "redis.fullname" -}}
+{{- printf "%s-%s" .Release.Name "anchore-ui-redis" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return Anchore Engine default admin password
+*/}}
+{{- define "anchore-engine.defaultAdminPassword" -}}
+{{- if .Values.anchoreGlobal.defaultAdminPassword }}
+    {{- .Values.anchoreGlobal.defaultAdminPassword -}}
+{{- else -}}
+    {{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}

--- a/stable/anchore-engine/templates/analyzer_configmap.yaml
+++ b/stable/anchore-engine/templates/analyzer_configmap.yaml
@@ -1,0 +1,19 @@
+{{- $component := "analyzer" -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "anchore-engine.analyzer.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  analyzer_config.yaml: |
+    {{- with .Values.anchoreAnalyzer.configFile }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/stable/anchore-engine/templates/analyzer_deployment.yaml
+++ b/stable/anchore-engine/templates/analyzer_deployment.yaml
@@ -1,0 +1,198 @@
+{{- $component := "analyzer" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "anchore-engine.analyzer.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreAnalyzer.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anchore-engine.fullname" . }}
+      component: {{ $component }}
+  replicas: {{ .Values.anchoreAnalyzer.replicaCount }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "anchore-engine.fullname" . }}
+        component: {{ $component }}
+        {{- with .Values.anchoreAnalyzer.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.anchoreAnalyzer.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+    {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+    {{- else }}
+      {{- with .Values.anchoreGlobal.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        command: ["/cloud_sql_proxy"]
+        args:
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
+        volumeMounts:
+        - mountPath: /var/{{ .Values.cloudsql.serviceAccSecretName }}
+          name: {{ .Values.cloudsql.serviceAccSecretName }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      - name: {{ .Chart.Name }}-{{ $component }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- else }}
+        image: {{ .Values.anchoreGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "analyzer"]
+        {{- else }}
+        args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "analyzer"]
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreAnalyzer.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - name: analyzer-api
+          containerPort: {{ .Values.anchoreAnalyzer.containerPort }}
+        volumeMounts:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- end }}
+        - name: analyzer-config-volume
+          mountPath: /anchore_service/analyzer_config.yaml
+          subPath: analyzer_config.yaml
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        - name: {{ $component }}-scratch
+          mountPath: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: analyzer-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: analyzer-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreAnalyzer.resources | nindent 10 }}
+      volumes:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          secret:
+            secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
+        {{- end }}
+        - name: config-volume
+          configMap:
+            name: {{ template "anchore-engine.fullname" .}}
+        - name: {{ $component }}-scratch
+          {{ toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        {{- end }}
+        - name: analyzer-config-volume
+          configMap:
+            name: {{ template "anchore-engine.analyzer.fullname" . }}
+        {{- with .Values.anchoreGlobal.certStoreSecretName }}
+        - name: certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - name: {{ .Values.cloudsql.serviceAccSecretName }}
+          secret:
+            secretName: {{ .Values.cloudsql.serviceAccSecretName }}
+        {{- end }}
+      {{- with .Values.anchoreAnalyzer.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreAnalyzer.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreAnalyzer.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/anchore-engine/templates/api_deployment.yaml
+++ b/stable/anchore-engine/templates/api_deployment.yaml
@@ -1,0 +1,522 @@
+{{- $component := "api" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "anchore-engine.api.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreApi.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anchore-engine.fullname" . }}
+      component: {{ $component }}
+  replicas: {{ .Values.anchoreApi.replicaCount }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "anchore-engine.fullname" . }}
+        component: {{ $component }}
+        {{- with .Values.anchoreApi.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.anchoreApi.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+    {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+    {{- else }}
+      {{- with .Values.anchoreGlobal.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        command: ["/cloud_sql_proxy"]
+        args:
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
+        volumeMounts:
+        - mountPath: /var/{{ .Values.cloudsql.serviceAccSecretName }}
+          name: {{ .Values.cloudsql.serviceAccSecretName }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      - name: "{{ .Chart.Name }}-{{ $component }}"
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- else }}
+        image: {{ .Values.anchoreGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "apiext"]
+        {{- else }}
+        args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "apiext"]
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreApi.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ANCHORE_CLI_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+              key: ANCHORE_ADMIN_PASSWORD
+        ports:
+        - containerPort: {{ .Values.anchoreApi.service.port }}
+          name: external-api
+        volumeMounts:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- end }}
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: external-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: external-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreApi.resources | nindent 10 }}
+      {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseRbac.enabled }}
+      - name: {{ .Chart.Name }}-rbac-manager
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "rbac_manager"]
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreEnterpriseRbac.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - containerPort: {{ .Values.anchoreEnterpriseRbac.service.apiPort }}
+          name: rbac-manager
+        volumeMounts:
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        - name: enterprise-config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: rbac-manager
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: rbac-manager
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreEnterpriseRbac.managerResources | nindent 10 }}
+      - name: {{ .Chart.Name }}-rbac-authorizer
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "rbac_authorizer"]
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreEnterpriseRbac.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - containerPort: {{ .Values.anchoreEnterpriseRbac.service.authPort }}
+          name: rbac-auth
+        volumeMounts:
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        - name: enterprise-config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        livenessProbe:
+          exec:
+            command:
+              - curl
+              - -f
+              - 'localhost:{{ .Values.anchoreEnterpriseRbac.service.authPort }}/health'
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          exec:
+            command:
+              - curl
+              - -f
+              - 'localhost:{{ .Values.anchoreEnterpriseRbac.service.authPort }}/health'
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreEnterpriseRbac.authResources | nindent 10 }}
+      {{- end }}
+      {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseReports.enabled }}
+      - name: "{{ .Chart.Name }}-reports"
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "reports"]
+        ports:
+        - containerPort: {{ .Values.anchoreEnterpriseReports.service.port }}
+          name: reports-api
+        envFrom:
+        - secretRef:
+            name: {{ template "anchore-engine.fullname" . }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreEnterpriseReports.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - name: enterprise-config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: reports-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: reports-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreEnterpriseReports.resources | nindent 10 }}
+      {{- end }}
+      {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseNotifications.enabled }}
+      - name: "{{ .Chart.Name }}-notifications"
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "notifications"]
+        ports:
+        - containerPort: {{ .Values.anchoreEnterpriseNotifications.service.port }}
+          name: notifi-api
+        envFrom:
+        - secretRef:
+            name: {{ template "anchore-engine.fullname" . }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreEnterpriseNotifications.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - name: enterprise-config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: notifi-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: notifi-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreEnterpriseNotifications.resources | nindent 10 }}
+      {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "anchore-engine.fullname" . }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        {{- end }}
+        {{ if and .Values.anchoreEnterpriseGlobal.enabled (or .Values.anchoreEnterpriseRbac.enabled .Values.anchoreEnterpriseReports.enabled) }}
+        - name: anchore-license
+          secret:
+            secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
+        - name: enterprise-config-volume
+          configMap:
+            name: {{ template "anchore-engine.enterprise.fullname" . }}
+        {{- end}}
+        {{- with .Values.anchoreGlobal.certStoreSecretName }}
+        - name: certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - name: {{ .Values.cloudsql.serviceAccSecretName }}
+          secret:
+            secretName: {{ .Values.cloudsql.serviceAccSecretName }}
+        {{- end }}
+      {{- with .Values.anchoreApi.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreApi.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreApi.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "anchore-engine.api.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreApi.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.anchoreApi.service.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.anchoreApi.service.type }}
+  ports:
+    - name: anchore-external-api
+      port: {{ .Values.anchoreApi.service.port }}
+      targetPort: {{ .Values.anchoreApi.service.port }}
+      protocol: TCP
+    {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseRbac.enabled }}
+    - name: anchore-rbac-manager
+      port: {{ .Values.anchoreEnterpriseRbac.service.apiPort }}
+      targetPort: {{ .Values.anchoreEnterpriseRbac.service.apiPort }}
+      protocol: TCP
+    {{- end }}
+    {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseReports.enabled }}
+    - name: reports-api
+      port: {{ .Values.anchoreEnterpriseReports.service.port }}
+      targetPort: {{ .Values.anchoreEnterpriseReports.service.port }}
+      protocol: TCP
+    {{- end }}
+    {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseNotifications.enabled }}
+    - name: notifi-api
+      port: {{ .Values.anchoreEnterpriseNotifications.service.port }}
+      targetPort: {{ .Values.anchoreEnterpriseNotifications.service.port }}
+      protocol: TCP
+    {{- end }}
+  selector:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}

--- a/stable/anchore-engine/templates/catalog_deployment.yaml
+++ b/stable/anchore-engine/templates/catalog_deployment.yaml
@@ -1,0 +1,220 @@
+{{- $component := "catalog" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "anchore-engine.catalog.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreCatalog.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anchore-engine.fullname" . }}
+      component: {{ $component }}
+  replicas: {{ .Values.anchoreCatalog.replicaCount }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "anchore-engine.fullname" . }}
+        component: {{ $component }}
+        {{- with .Values.anchoreCatalog.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.anchoreCatalog.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+    {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+    {{- else }}
+      {{- with .Values.anchoreGlobal.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        command: ["/cloud_sql_proxy"]
+        args:
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
+        volumeMounts:
+        - mountPath: /var/{{ .Values.cloudsql.serviceAccSecretName }}
+          name: {{ .Values.cloudsql.serviceAccSecretName }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      - name: {{ .Chart.Name }}-{{ $component }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- else }}
+        image: {{ .Values.anchoreGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "catalog"]
+        {{- else }}
+        args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "catalog"]
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreCatalog.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - name: catalog
+          containerPort: {{ .Values.anchoreCatalog.service.port }}
+        volumeMounts:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- end }}
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: catalog
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: catalog
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreCatalog.resources | nindent 10 }}
+      volumes:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          secret:
+            secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
+        {{- end }}
+        - name: config-volume
+          configMap:
+            name: {{ template "anchore-engine.fullname" . }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.certStoreSecretName }}
+        - name: certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - name: {{ .Values.cloudsql.serviceAccSecretName }}
+          secret:
+            secretName: {{ .Values.cloudsql.serviceAccSecretName }}
+        {{- end }}
+      {{- with .Values.anchoreCatalog.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreCatalog.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreCatalog.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "anchore-engine.catalog.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreCatalog.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.anchoreCatalog.service.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.anchoreCatalog.service.type }}
+  ports:
+    - name: anchore-catalog-api
+      port: {{ .Values.anchoreCatalog.service.port }}
+      targetPort: {{ .Values.anchoreCatalog.service.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -1,0 +1,237 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "anchore-engine.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  config.yaml: |
+    # Anchore Service Configuration File from ConfigMap
+    service_dir: {{ .Values.anchoreGlobal.serviceDir }}
+    tmp_dir: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+    log_level: {{ .Values.anchoreGlobal.logLevel }}
+    image_analyze_timeout_seconds: {{ .Values.anchoreGlobal.imageAnalyzeTimeoutSeconds }}
+    cleanup_images: {{ .Values.anchoreGlobal.cleanupImages }}
+    allow_awsecr_iam_auto: {{ .Values.anchoreGlobal.allowECRUseIAMRole }}
+    host_id: "${ANCHORE_POD_NAME}"
+    internal_ssl_verify: {{ .Values.anchoreGlobal.internalServicesSsl.verifyCerts }}
+    auto_restart_services: false
+
+    {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+    license_file: /home/anchore/license.yaml
+    {{- end }}
+
+    global_client_connect_timeout: {{ default 0 .Values.anchoreGlobal.clientConnectTimeout }}
+    global_client_read_timeout: {{ default 0 .Values.anchoreGlobal.clientReadTimeout }}
+
+    metrics:
+      enabled: {{ .Values.anchoreGlobal.enableMetrics }}
+      auth_disabled: {{ .Values.anchoreGlobal.metricsAuthDisabled }}
+    {{ if .Values.anchoreGlobal.webhooksEnabled }}
+    webhooks:
+      {{- toYaml .Values.anchoreGlobal.webhooks | nindent 6 }}
+    {{ end }}
+    # Configure what feeds to sync.
+    # The sync will hit http://ancho.re/feeds, if any outbound firewall config needs to be set in your environment.
+    feeds:
+      sync_enabled: true
+      selective_sync:
+        # If enabled only sync specific feeds instead of all that are found.
+        enabled: true
+        feeds:
+          {{- if not .Values.anchoreEnterpriseGlobal.enabled }}
+          github: {{ default "true" .Values.anchoreGlobal.syncGithub }}
+          {{- end }}
+          # Vulnerabilities feed is the feed for distro cve sources (redhat, debian, ubuntu, oracle, alpine....)
+          vulnerabilities: {{ default "true" .Values.anchoreGlobal.syncVulnerabilites }}
+          # NVD Data is used for non-distro CVEs (jars, npm, etc) that are not packaged and released by distros as rpms, debs, etc
+          nvdv2: {{ default "true" .Values.anchoreGlobal.syncNvd }}
+          # Warning: enabling the package sync causes the service to require much
+          #   more memory to do process the significant data volume. We recommend at least 4GB available for the container
+          {{- if and (and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled) (or .Values.anchoreEnterpriseFeeds.gemDriverEnabled .Values.anchoreEnterpriseFeeds.npmDriverEnabled) }}
+          packages: true
+          {{- else }}
+          packages: {{ default "false" .Values.anchoreGlobal.syncPackages }}
+          {{- end }}
+          # Enabling vulndb syncs vulndb vulnerability data from an on-premise anchore enterprise feeds service. Please contact
+          # anchore support for finding out more about this service
+          {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
+          vulndb: {{ default "true" .Values.anchoreEnterpriseFeeds.vulndbDriverEnabled }}
+          # Enabling microsoft syncs MSRC data from an on-premise anchore enterprise feeds service. Please contact
+          # anchore support for finding out more about this service
+          microsoft: {{ .Values.anchoreEnterpriseFeeds.msrcDriverEnabled }}
+          {{- else }}
+          vulndb: false
+          microsoft: false
+          {{- end }}
+          # Sync github data if available for GHSA matches
+          github: {{ default "true" .Values.anchoreGlobal.syncGithub }}
+      {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
+      {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+      url: "https://{{- template "anchore-engine.enterprise-feeds.fullname" . }}:{{- .Values.anchoreEnterpriseFeeds.service.port }}/v1/feeds"
+      {{- else }}
+      url: "http://{{- template "anchore-engine.enterprise-feeds.fullname" . }}:{{- .Values.anchoreEnterpriseFeeds.service.port }}/v1/feeds"
+      {{- end }}
+      ssl_verify: {{ .Values.anchoreGlobal.internalServicesSsl.verifyCerts }}
+      client_url:
+      token_url:
+      {{- else }}
+      client_url: "https://ancho.re/v1/account/users"
+      token_url: "https://ancho.re/oauth/token"
+      anonymous_user_username: anon@ancho.re
+      anonymous_user_password: pbiU2RYZ2XrmYQ
+      {{- end }}
+      connection_timeout_seconds: {{ default 3 .Values.anchoreGlobal.feedsConnectionTimeout }}
+      read_timeout_seconds: {{ default 180 .Values.anchoreGlobal.feedsReadTimeout }}
+    default_admin_password: ${ANCHORE_ADMIN_PASSWORD}
+    default_admin_email: {{ .Values.anchoreGlobal.defaultAdminEmail }}
+
+    # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
+    # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
+    keys:
+      secret: {{ .Values.anchoreGlobal.saml.secret }}
+      {{- with .Values.anchoreGlobal.saml.publicKeyName }}
+      public_key_path: /home/anchore/certs/{{- . }}
+      {{- end }}
+      {{- with .Values.anchoreGlobal.saml.privateKeyName }}
+      private_key_path: /home/anchore/certs/{{- . }}
+      {{- end }}
+
+    # Configuring supported user authentication and credential management
+    user_authentication:
+      oauth:
+        enabled: {{ .Values.anchoreGlobal.oauthEnabled }}
+        default_token_expiration_seconds: {{ .Values.anchoreGlobal.oauthTokenExpirationSeconds }}
+
+      # Set this to True to enable storing user passwords only as secure hashes in the db. This can dramatically increase CPU usage if you
+      # don't also use oauth and tokens for internal communications (which requires keys/secret to be configured as well)
+      # WARNING: you should not change this after a system has been initialized as it may cause a mismatch in existing passwords
+      hashed_passwords: {{ .Values.anchoreGlobal.hashedPasswords }}
+
+    credentials:
+      database:
+        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName -}}"
+        {{- else }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
+        {{- end }}
+        db_connect_args:
+          timeout: {{ .Values.anchoreGlobal.dbConfig.timeout }}
+          ssl: false
+        db_pool_size: {{ .Values.anchoreGlobal.dbConfig.connectionPoolSize }}
+        db_pool_max_overflow: {{ .Values.anchoreGlobal.dbConfig.connectionPoolMaxOverflow }}
+    services:
+      apiext:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.api.fullname" . }}
+        listen: 0.0.0.0
+        port: {{ .Values.anchoreApi.service.port }}
+        {{- if .Values.anchoreApi.external }}
+        {{- if .Values.anchoreApi.external.use_tls }}
+        external_tls: {{ .Values.anchoreApi.external.use_tls }}
+        {{- end }}
+        {{- if .Values.anchoreApi.external.hostname }}
+        external_hostname: {{ .Values.anchoreApi.external.hostname }}
+        {{- end }}
+        external_port: {{ .Values.anchoreApi.external.port | default "null" }}
+        {{- end }}
+        {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseRbac.enabled }}
+        authorization_handler: external
+        authorization_handler_config:
+          endpoint: "http://localhost:{{- .Values.anchoreEnterpriseRbac.service.authPort }}"
+        {{- end }}
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+      analyzer:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.analyzer.fullname" . }}
+        listen: 0.0.0.0
+        port: {{ .Values.anchoreAnalyzer.containerPort }}
+        cycle_timer_seconds: 1
+        cycle_timers:
+          {{- toYaml .Values.anchoreAnalyzer.cycleTimers | nindent 10 }}
+        max_threads: {{ .Values.anchoreAnalyzer.concurrentTasksPerWorker }}
+        analyzer_driver: 'nodocker'
+        {{- if gt .Values.anchoreAnalyzer.layerCacheMaxGigabytes 0.0 }}
+        layer_cache_enable: true
+        {{- else }}
+        layer_cache_enable: false
+        {{- end }}
+        layer_cache_max_gigabytes: {{ .Values.anchoreAnalyzer.layerCacheMaxGigabytes }}
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+      catalog:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.catalog.fullname" . }}
+        listen: 0.0.0.0
+        port: {{ .Values.anchoreCatalog.service.port }}
+        cycle_timer_seconds: 1
+        cycle_timers:
+          # Interval to check for an update to a tag
+          image_watcher: {{ .Values.anchoreCatalog.cycleTimers.image_watcher }}
+          # Interval to run a policy evaluation on images with the policy_eval subscription activated.
+          policy_eval: {{ .Values.anchoreCatalog.cycleTimers.policy_eval }}
+          # Interval to run a vulnerability scan on images with the vuln_update subscription activated.
+          vulnerability_scan: {{ .Values.anchoreCatalog.cycleTimers.vulnerability_scan }}
+          # Interval at which the catalog looks for new work to put on the image analysis queue.
+          analyzer_queue: {{ .Values.anchoreCatalog.cycleTimers.analyzer_queue }}
+          # Interval notifications will be processed for state changes
+          {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseNotifications.enabled }}
+          notifications: 0
+          {{- else }}
+          notifications: {{ .Values.anchoreCatalog.cycleTimers.notifications }}
+          {{- end }}
+          # Intervals service state updates are polled for the system status
+          service_watcher: {{ .Values.anchoreCatalog.cycleTimers.service_watcher }}
+          # Interval between checks to repo for new tags
+          repo_watcher: {{ .Values.anchoreCatalog.cycleTimers.repo_watcher }}
+        event_log:
+          {{- toYaml .Values.anchoreCatalog.events | nindent 10 }}
+        archive:
+          {{- toYaml .Values.anchoreCatalog.archive | nindent 10 }}
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+      simplequeue:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.simplequeue.fullname" . }}
+        listen: 0.0.0.0
+        port: {{ .Values.anchoreSimpleQueue.service.port }}
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+      policy_engine:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.policy-engine.fullname" . }}
+        listen: 0.0.0.0
+        port: {{ .Values.anchorePolicyEngine.service.port }}
+        cycle_timer_seconds: 1
+        cycle_timers:
+          {{- toYaml .Values.anchorePolicyEngine.cycleTimers | nindent 10 }}
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+

--- a/stable/anchore-engine/templates/engine_configmap_env.yaml
+++ b/stable/anchore-engine/templates/engine_configmap_env.yaml
@@ -1,0 +1,22 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "anchore-engine.fullname" . }}-env
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  ANCHORE_DB_NAME: {{ index .Values "postgresql" "postgresDatabase" | quote }}
+  ANCHORE_DB_USER: {{ index .Values "postgresql" "postgresUser" | quote }}
+  {{- if and (index .Values "postgresql" "externalEndpoint") (not (index .Values "postgresql" "enabled")) }}
+  ANCHORE_DB_HOST: {{ index .Values "postgresql" "externalEndpoint" | quote }}
+  {{- else if and (index .Values "cloudsql" "enabled") (not (index .Values "postgresql" "enabled")) }}
+  ANCHORE_DB_HOST: "localhost:5432"
+  {{- else }}
+  ANCHORE_DB_HOST: "{{ template "postgres.fullname" . }}:5432"
+  {{- end }}

--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-engine-upgrade"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-engine-upgrade"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+     {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+    {{- else }}
+      {{- with .Values.anchoreGlobal.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      restartPolicy: Never
+      containers:
+      - name: "{{ .Release.Name }}-enterprise-upgrade"
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- else }}
+        image: {{ .Values.anchoreGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
+        args: ["/bin/bash", "-c", "anchore-manager db --db-use-ssl --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{ .Values.anchoreGlobal.dbConfig.sslMode }}\\&sslrootcert=/home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask"]
+        {{- else }}
+        args: ["/bin/bash", "-c", "anchore-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask"]
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        volumeMounts:
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+      {{- with .Values.anchoreGlobal.certStoreSecretName }}
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ . }}
+      {{- end }}

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -1,0 +1,136 @@
+{{- if and .Values.anchoreEnterpriseGlobal.enabled (or .Values.anchoreEnterpriseRbac.enabled .Values.anchoreEnterpriseReports.enabled) -}}
+{{- $component := "enterprise" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "anchore-engine.enterprise.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  config.yaml: |
+    # Anchore Enterprise Service Configuration File
+
+    # General system-wide configuration options, these should not need to
+    # be altered for basic operation
+    #
+    service_dir: {{ .Values.anchoreGlobal.serviceDir }}
+    tmp_dir: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+    log_level: {{ .Values.anchoreGlobal.logLevel }}
+    cleanup_images: {{ .Values.anchoreGlobal.cleanupImages }}
+
+    allow_awsecr_iam_auto: {{ .Values.anchoreGlobal.allowECRUseIAMRole }}
+    host_id: "${ANCHORE_POD_NAME}"
+    internal_ssl_verify: {{ .Values.anchoreGlobal.internalServicesSsl.verifyCerts }}
+    auto_restart_services: false
+    license_file: /home/anchore/license.yaml
+
+    global_client_connect_timeout: {{ default 0 .Values.anchoreGlobal.clientConnectTimeout }}
+    global_client_read_timeout: {{ default 0 .Values.anchoreGlobal.clientReadTimeout }}
+
+    metrics:
+      enabled: {{ .Values.anchoreGlobal.enableMetrics }}
+      auth_disabled: {{ .Values.anchoreGlobal.metricsAuthDisabled }}
+
+    # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
+    # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
+    keys:
+      secret: {{ .Values.anchoreGlobal.saml.secret }}
+      {{- with .Values.anchoreGlobal.saml.publicKeyName }}
+      public_key_path: /home/anchore/certs/{{- . }}
+      {{- end }}
+      {{- with .Values.anchoreGlobal.saml.privateKeyName }}
+      private_key_path: /home/anchore/certs/{{- . }}
+      {{- end }}
+
+    # Configuring supported user authentication and credential management
+    user_authentication:
+      oauth:
+        enabled: {{ .Values.anchoreGlobal.oauthEnabled }}
+        default_token_expiration_seconds: {{ .Values.anchoreGlobal.oauthTokenExpirationSeconds }}
+
+      # Set this to True to enable storing user passwords only as secure hashes in the db. This can dramatically increase CPU usage if you
+      # don't also use oauth and tokens for internal communications (which requires keys/secret to be configured as well)
+      # WARNING: you should not change this after a system has been initialized as it may cause a mismatch in existing passwords
+      hashed_passwords: {{ .Values.anchoreGlobal.hashedPasswords }}
+
+    credentials:
+      database:
+        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }}"
+        {{- else }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
+        {{- end }}
+        db_connect_args:
+          timeout: {{ .Values.anchoreGlobal.dbConfig.timeout }}
+          ssl: false
+        db_pool_size: {{ .Values.anchoreGlobal.dbConfig.connectionPoolSize }}
+        db_pool_max_overflow: {{ .Values.anchoreGlobal.dbConfig.connectionPoolMaxOverflow }}
+
+    services:
+      {{- if .Values.anchoreEnterpriseRbac.enabled }}
+      # This should never be exposed outside of linked containers/localhost. It is used only for internal service access
+      rbac_authorizer:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: localhost
+        listen: 127.0.0.1
+        port: {{ .Values.anchoreEnterpriseRbac.service.authPort }}
+      rbac_manager:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.api.fullname" . }}
+        listen: 0.0.0.0
+        port: {{ .Values.anchoreEnterpriseRbac.service.apiPort }}
+        authorization_handler: external
+        authorization_handler_config:
+          endpoint: "http://localhost:{{- .Values.anchoreEnterpriseRbac.service.authPort }}"
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+      {{- end }}
+      {{- if .Values.anchoreEnterpriseReports.enabled }}
+      reports:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.enterprise-reports.fullname" . }}
+        listen: '0.0.0.0'
+        port: {{ .Values.anchoreEnterpriseReports.service.port }}
+        enable_graphiql: "{{ .Values.anchoreEnterpriseReports.enableGraphql }}"
+        enable_data_ingress: "{{ .Values.anchoreEnterpriseReports.enableDataIngress }}"
+        cycle_timers:
+          {{- toYaml .Values.anchoreEnterpriseReports.cycleTimers | nindent 10 }}
+        {{- if .Values.anchoreEnterpriseRbac.enabled }}
+        authorization_handler: external
+        authorization_handler_config:
+          endpoint: "http://localhost:{{- .Values.anchoreEnterpriseRbac.service.authPort }}"
+        {{- end }}
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+      {{- end }}
+      {{- if .Values.anchoreEnterpriseNotifications.enabled }}
+      notifications:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.enterprise-notifications.fullname" . }}
+        listen: '0.0.0.0'
+        port: {{ .Values.anchoreEnterpriseNotifications.service.port }}
+        authorization_handler: external
+        authorization_handler_config:
+          endpoint: "http://localhost:{{- .Values.anchoreEnterpriseRbac.service.authPort }}"
+        cycle_timers:
+          {{- toYaml .Values.anchoreEnterpriseNotifications.cycleTimers | nindent 10 }}
+        ui_url: {{ include "anchore-engine.enterprise-ui.fullname" . | quote }}
+      {{- end }}
+{{- end -}}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -1,0 +1,137 @@
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
+{{- $component := "enterprise-feeds" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  config.yaml: |
+    # Anchore Enterprise Service Configuration File
+    # General system-wide configuration options, these should not need to
+    # be altered for basic operation
+    service_dir: {{ .Values.anchoreGlobal.serviceDir }}
+    tmp_dir: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+    log_level: {{ .Values.anchoreGlobal.logLevel }}
+    cleanup_images: {{ .Values.anchoreGlobal.cleanupImages }}
+    allow_awsecr_iam_auto: {{ .Values.anchoreGlobal.allowECRUseIAMRole }}
+    host_id: "${ANCHORE_POD_NAME}"
+    internal_ssl_verify: {{ .Values.anchoreGlobal.internalServicesSsl.verifyCerts }}
+    auto_restart_services: false
+    license_file: /home/anchore/license.yaml
+    metrics:
+      enabled: {{ .Values.anchoreGlobal.enableMetrics }}
+
+    # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
+    # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
+    keys:
+      secret: {{ .Values.anchoreGlobal.saml.secret }}
+      {{- with .Values.anchoreGlobal.saml.publicKeyName }}
+      public_key_path: /home/anchore/certs/{{- . }}
+      {{- end }}
+      {{- with .Values.anchoreGlobal.saml.privateKeyName }}
+      private_key_path: /home/anchore/certs/{{- . }}
+      {{- end }}
+
+    # Configuring supported user authentication and credential management
+    user_authentication:
+      oauth:
+        enabled: {{ .Values.anchoreGlobal.oauthEnabled }}
+        default_token_expiration_seconds: {{ .Values.anchoreGlobal.oauthTokenExpirationSeconds }}
+
+      # Set this to True to enable storing user passwords only as secure hashes in the db. This can dramatically increase CPU usage if you
+      # don't also use oauth and tokens for internal communications (which requires keys/secret to be configured as well)
+      # WARNING: you should not change this after a system has been initialized as it may cause a mismatch in existing passwords
+      hashed_passwords: {{ .Values.anchoreGlobal.hashedPasswords }}
+
+    credentials:
+      database:
+        {{- if .Values.anchoreEnterpriseFeeds.dbConfig.ssl }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreEnterpriseFeeds.dbConfig.sslRootCertName }}"
+        {{- else }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
+        {{- end }}
+        db_connect_args:
+          timeout: {{ .Values.anchoreEnterpriseFeeds.dbConfig.timeout }}
+          ssl: false
+        db_pool_size: {{ .Values.anchoreEnterpriseFeeds.dbConfig.connectionPoolSize }}
+        db_pool_max_overflow: {{ .Values.anchoreEnterpriseFeeds.dbConfig.connectionPoolMaxOverflow }}
+    services:
+      feeds:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: {{ template "anchore-engine.enterprise-feeds.fullname" . }}
+        listen: 0.0.0.0
+        port: {{ .Values.anchoreEnterpriseFeeds.service.port }}
+        # Time delay in seconds between consecutive driver runs for processing data
+        cycle_timers:
+          {{- toYaml .Values.anchoreEnterpriseFeeds.cycleTimers | nindent 10 }}
+        # Staging space for holding normalized output from drivers.
+        local_workspace: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+        # Drivers process data from external sources and store normalized data in local_workspace. Processing large data sets
+        # is a time consuming process for some drivers. To speed it up the container is shipped with pre-loaded data which is used
+        # by default if local_workspace is empty.
+        workspace_preload:
+          # Do not use pre-loaded data if local_workspace is empty. Drivers will generate normalized data from scratch
+          # disabled: true
+          # To load the workspace from a different location, uncomment and configure workspace_preload_file property to point to the tar.gz file
+          workspace_preload_file: "/workspace_preload/data.tar.gz"
+        # If api_only is set to true, the service will not update feed data in the system.
+        # API end points will be functional and serve feed data if any is available.
+        api_only: {{ default "false" .Values.anchoreEnterpriseFeeds.apiOnly }}
+        drivers:
+          # Configuration section for drivers collecting and processing feed data.
+          # All drivers are enabled by default unless explicitly disabled. npm and gem drivers are explicitly disabled out of the box
+          npm:
+            enabled: {{ default "false" .Values.anchoreEnterpriseFeeds.npmDriverEnabled }}
+          gem:
+            # rubygem data comes packaged as a PostgreSQL dump file. gem driver loads the pg dump and normalizes the data.
+            # To enable gem driver comment the enabled property and uncomment the db_connect property.
+            enabled: {{ default "false" .Values.anchoreEnterpriseFeeds.gemDriverEnabled }}
+            db_connect: {{ default "'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/gems'" .Values.anchoreEnterpriseFeeds.gemDbEndpoint }}
+          amzn:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.amazonDriverEnabled }}
+          centos:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.centosDriverEnabled }}
+          debian:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.debianDriverEnabled }}
+          ubuntu:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.ubuntuDriverEnabled }}
+          rhel:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.rhelDriverEnabled }}
+          ol:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.olDriverEnabled }}
+          alpine:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.alpineDriverEnabled }}
+          snyk:
+            enabled: {{ default "false" .Values.anchoreEnterpriseFeeds.snykDriverEnabled }}
+          nvddb:
+            enabled: {{ default "false" .Values.anchoreEnterpriseFeeds.nvdDriverEnabled }}
+          nvdv2:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.nvdv2DriverEnabled }}
+          vulndb:
+            enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.vulndbDriverEnabled }}
+          msrc:
+            enabled: {{ .Values.anchoreEnterpriseFeeds.msrcDriverEnabled }}
+            api_key: {{ .Values.anchoreEnterpriseFeeds.msrcApiKey }}
+            {{- with .Values.anchoreEnterpriseFeeds.msrcWhitelist }}
+            whitelist:
+              - {{ . }}
+            {{- end }}
+          github:
+            enabled: {{ .Values.anchoreEnterpriseFeeds.githubDriverEnabled }}
+            token: {{ .Values.anchoreEnterpriseFeeds.githubDriverToken }}
+        {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
+        ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"
+        ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
+        {{- end }}
+{{- end -}}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap_env.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap_env.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
+{{- $component := "enterprise-feeds" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}-env
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  ANCHORE_DB_NAME: {{ index .Values "anchore-feeds-db" "postgresDatabase" | quote }}
+  ANCHORE_DB_USER: {{ index .Values "anchore-feeds-db" "postgresUser"  | quote }}
+  {{- if and (index .Values "anchore-feeds-db" "externalEndpoint") (not (index .Values "anchore-feeds-db" "enabled")) }}
+  ANCHORE_DB_HOST: {{ index .Values "anchore-feeds-db" "externalEndpoint" | quote }}
+  {{- else if and (index .Values "cloudsql" "enabled") (not (index .Values "anchore-feeds-db" "enabled")) }}
+  ANCHORE_DB_HOST: "localhost:5432"
+  {{- else }}
+  ANCHORE_DB_HOST: "{{ template "postgres.anchore-feeds-db.fullname" . }}:5432"
+  {{- end }}
+{{- end }}

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -1,0 +1,212 @@
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
+{{- $component := "enterprise-feeds" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreEnterpriseFeeds.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anchore-engine.fullname" . }}
+      component: {{ $component }}
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "anchore-engine.fullname" . }}
+        component: {{ $component }}
+        {{- with .Values.anchoreEnterpriseFeeds.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.anchoreEnterpriseFeeds.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+      containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        command: ["/cloud_sql_proxy"]
+        args:
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
+        volumeMounts:
+        - mountPath: /var/{{ .Values.cloudsql.serviceAccSecretName }}
+          name: {{ .Values.cloudsql.serviceAccSecretName }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      - name: "{{ .Chart.Name }}-{{ $component }}"
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "feeds"]
+        ports:
+        - containerPort: {{ .Values.anchoreEnterpriseFeeds.service.port }}
+          name: feeds-api
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreEnterpriseFeeds.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "anchore-engine.fullname" . }}
+              key: .feedsDbPassword
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        - name: {{ $component }}-scratch
+          mountPath: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: feeds-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: feeds-api
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreEnterpriseFeeds.resources | nindent 10 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}
+        - name: {{ $component}}-scratch
+          {{ toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        {{- end }}
+        - name: anchore-license
+          secret:
+            secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - name: {{ .Values.cloudsql.serviceAccSecretName }}
+          secret:
+            secretName: {{ .Values.cloudsql.serviceAccSecretName }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.certStoreSecretName }}
+        - name: certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+      {{- with .Values.anchoreEnterpriseFeeds.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreEnterpriseFeeds.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreEnterpriseFeeds.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreEnterpriseFeeds.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.anchoreEnterpriseFeeds.service.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.anchoreEnterpriseFeeds.service.type }}
+  ports:
+    - name: feeds-api
+      port: {{ .Values.anchoreEnterpriseFeeds.service.port }}
+      targetPort: {{ .Values.anchoreEnterpriseFeeds.service.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}
+
+{{- end -}}

--- a/stable/anchore-engine/templates/enterprise_ui_config_secret.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_config_secret.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseUi.enabled -}}
+{{- $component := "enterprise-ui" -}}
+
+# Using a secret until UI app supports ENV vars inside the config file. Redis password is included in config.
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "anchore-engine.enterprise-ui.fullname" . | quote }}
+  labels:
+    app: {{ include "anchore-engine.fullname" . | quote }}
+    component: {{ $component }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+type: Opaque
+stringData:
+  config-ui.yaml: |
+    {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+    engine_uri: 'https://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreApi.service.port }}/v1'
+    {{- else }}
+    engine_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreApi.service.port }}/v1'
+    {{- end }}
+    {{- if and (index .Values "anchore-ui-redis" "externalEndpoint") (not (index .Values "anchore-ui-redis" "enabled")) }}
+    redis_uri: '{{ index .Values "anchore-ui-redis" "externalEndpoint" }}'
+    {{- else }}
+    redis_uri: 'redis://:{{ index .Values "anchore-ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379'
+    {{- end }}
+  {{- if .Values.anchoreEnterpriseRbac.enabled }}
+    {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+    rbac_uri: 'https://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseRbac.service.apiPort }}/v1'
+    {{- else }}
+    rbac_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseRbac.service.apiPort }}/v1'
+    {{- end }}
+  {{- end }}
+  {{- if .Values.anchoreEnterpriseReports.enabled }}
+    {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+    reports_uri: 'https://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseReports.service.port}}/v1'
+    {{- else}}
+    reports_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseReports.service.port}}/v1'
+    {{- end }}
+  {{- end }}
+  {{- if .Values.anchoreEnterpriseNotifications.enabled }}
+    {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+    notifications_uri: 'https://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseNotifications.service.port}}/v1'
+    {{- else}}
+    notifications_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseNotifications.service.port}}/v1'
+    {{- end }}
+  {{- end }}
+    {{- if and (and .Values.postgresql.externalEndpoint (not .Values.postgresql.enabled)) .Values.anchoreGlobal.dbConfig.ssl }}
+    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ .Values.postgresql.externalEndpoint }}/{{ .Values.postgresql.postgresDatabase }}?ssl=verify-full'
+    {{- else if and .Values.postgresql.externalEndpoint (not .Values.postgresql.enabled) }}
+    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ .Values.postgresql.externalEndpoint }}/{{ .Values.postgresql.postgresDatabase }}'
+    {{- else if and (index .Values "cloudsql" "enabled") (not (index .Values "postgresql" "enabled")) }}
+    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@localhost:5432/{{ .Values.postgresql.postgresDatabase }}'
+    {{- else }}
+    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ template "postgres.fullname" . }}:5432/{{ .Values.postgresql.postgresDatabase }}'
+    {{- end }}
+    license_path: '/home/anchore/'
+    enable_ssl: {{ .Values.anchoreEnterpriseUi.enableSsl }}
+    enable_proxy: {{ .Values.anchoreEnterpriseUi.enableProxy }}
+    allow_shared_login: {{ .Values.anchoreEnterpriseUi.enableSharedLogin }}
+    redis_flushdb: {{ .Values.anchoreEnterpriseUi.redisFlushdb }}
+    policy_hub_uri: {{ .Values.anchoreEnterpriseUi.policyHubUri }}
+    {{- with .Values.anchoreEnterpriseUi.customLinks }}
+    custom_links:
+      title: {{ .title }}
+      links:
+      {{- range .links }}
+        {{- with . }}
+        - title: {{ .title }}
+          uri: {{ .uri }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- with .Values.anchoreEnterpriseUi.enableAddRepositories }}
+    enable_add_repositories:
+      admin: {{ .admin }}
+      standard: {{ .standard }}
+    {{- end }}
+{{- end -}}

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -1,0 +1,182 @@
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseUi.enabled -}}
+{{- $component := "enterprise-ui" -}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "anchore-engine.enterprise-ui.fullname" . }}
+  labels:
+    app: {{ include "anchore-engine.fullname" . }}
+    component: {{ $component }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreEnterpriseUi.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anchore-engine.fullname" . }}
+      component: {{ $component }}
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "anchore-engine.fullname" . }}
+        component: {{ $component }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        {{- with .Values.anchoreEnterpriseUi.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.anchoreEnterpriseUi.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+      containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        command: ["/cloud_sql_proxy"]
+        args:
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
+        volumeMounts:
+        - mountPath: /var/{{ .Values.cloudsql.serviceAccSecretName }}
+          name: {{ .Values.cloudsql.serviceAccSecretName }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      - name: "{{ .Chart.Name }}-{{ $component }}"
+        image: {{ .Values.anchoreEnterpriseUi.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseUi.imagePullPolicy }}
+        env:
+        {{ if .Values.anchoreGlobal.dbConfig.ssl }}
+        - name: PGSSLROOTCERT
+          value: /home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }}
+        {{- end }}
+        {{ with .Values.anchoreEnterpriseUi.ldapsRootCaCertName }}
+        - name: NODE_EXTRA_CA_CERTS
+          value: /home/anchore/certs/{{- . }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreEnterpriseUi.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+          name: enterprise-ui
+        volumeMounts:
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        - name: anchore-ui-config
+          mountPath: /config/config-ui.yaml
+          subPath: config-ui.yaml
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        livenessProbe:
+          tcpSocket:
+            port: enterprise-ui
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /service/health
+            port: enterprise-ui
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreEnterpriseUi.resources | nindent 10 }}
+      volumes:
+      - name: anchore-license
+        secret:
+          secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
+      - name: anchore-ui-config
+        secret:
+          secretName: {{ template "anchore-engine.enterprise-ui.fullname" . }}
+      {{- with .Values.anchoreGlobal.certStoreSecretName }}
+      - name: certs
+        secret:
+          secretName: {{ . }}
+      {{- end }}
+      {{- if .Values.cloudsql.useExistingServiceAcc }}
+      - name: {{ .Values.cloudsql.serviceAccSecretName }}
+        secret:
+          secretName: {{ .Values.cloudsql.serviceAccSecretName }}
+      {{- end }}
+      {{- with .Values.anchoreEnterpriseUi.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.anchoreEnterpriseUi.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreEnterpriseUi.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreEnterpriseUi.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+     {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "anchore-engine.enterprise-ui.fullname" . | quote }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreEnterpriseUi.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.anchoreEnterpriseUi.service.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  sessionAffinity: {{ .Values.anchoreEnterpriseUi.service.sessionAffinity }}
+  type: {{ .Values.anchoreEnterpriseUi.service.type }}
+  ports:
+    - name: enterprise-ui
+      port: {{ .Values.anchoreEnterpriseUi.service.port }}
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}
+
+{{- end -}}

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.anchoreEnterpriseGlobal.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-enterprise-upgrade"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-3"
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-enterprise-upgrade"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+      restartPolicy: Never
+      containers:
+      - name: "{{ .Release.Name }}-enterprise-upgrade"
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
+        args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{ .Values.anchoreGlobal.dbConfig.sslMode }}\\&sslrootcert=/home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask"]
+        {{- else }}
+        args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask"]
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        volumeMounts:
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+    {{- with .Values.anchoreGlobal.certStoreSecretName }}
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ . }}
+      {{- end }}
+{{- end }}

--- a/stable/anchore-engine/templates/ingress.yaml
+++ b/stable/anchore-engine/templates/ingress.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
+kind: Ingress
+metadata:
+  name: {{ template "anchore-engine.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.ingress.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if or .Values.ingress.apiHosts .Values.ingress.uiHosts .Values.ingress.feedsHosts }}
+    {{- range .Values.ingress.apiHosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        - path: {{ $.Values.ingress.apiPath }}
+          backend:
+            serviceName: {{ template "anchore-engine.api.fullname" $ }}
+            servicePort: {{ $.Values.anchoreApi.service.port }}
+    {{- end }}
+    {{- range .Values.ingress.uiHosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        - path: {{ $.Values.ingress.uiPath }}
+          backend:
+            serviceName: {{ template "anchore-engine.enterprise-ui.fullname" $ }}
+            servicePort: {{ $.Values.anchoreEnterpriseUi.service.port }}
+    {{- end }}
+    {{- range .Values.ingress.feedsHosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        - path: {{ $.Values.ingress.feedsPath }}
+          backend:
+            serviceName: {{ template "anchore-engine.enterprise-feeds.fullname" $ }}
+            servicePort: {{ $.Values.anchoreEnterpriseFeeds.service.port }}
+    {{- end }}
+  {{- else }}
+    - http:
+        paths:
+        {{- with .Values.ingress.apiPath }}
+        - path: {{ . }}
+          backend:
+            serviceName: {{ template "anchore-engine.api.fullname" $ }}
+            servicePort: {{ $.Values.anchoreApi.service.port }}
+        {{- end }}
+        {{- with .Values.ingress.uiPath }}
+        - path: {{ . }}
+          backend:
+            serviceName: {{ template "anchore-engine.enterprise-ui.fullname" $ }}
+            servicePort: {{ $.Values.anchoreEnterpriseUi.service.port }}
+        {{- end }}
+        {{- with .Values.ingress.feedsPath }}
+        - path: {{ . }}
+          backend:
+            serviceName: {{ template "anchore-engine.enterprise-feeds.fullname" $ }}
+            servicePort: {{ $.Values.anchoreEnterpriseFeeds.service.port }}
+        {{- end }}
+  {{- end }}
+{{- end -}}

--- a/stable/anchore-engine/templates/policy_engine_deployment.yaml
+++ b/stable/anchore-engine/templates/policy_engine_deployment.yaml
@@ -1,0 +1,224 @@
+{{- $component := "policy" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "anchore-engine.policy-engine.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchorePolicyEngine.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anchore-engine.fullname" . }}
+      component: {{ $component }}
+  replicas: {{ .Values.anchorePolicyEngine.replicaCount }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "anchore-engine.fullname" . }}
+        component: {{ $component }}
+        {{- with .Values.anchorePolicyEngine.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.anchorePolicyEngine.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+    {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+    {{- else }}
+      {{- with .Values.anchoreGlobal.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        command: ["/cloud_sql_proxy"]
+        args:
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
+        volumeMounts:
+        - mountPath: /var/{{ .Values.cloudsql.serviceAccSecretName }}
+          name: {{ .Values.cloudsql.serviceAccSecretName }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      - name: {{ .Chart.Name }}-{{ $component }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- else }}
+        image: {{ .Values.anchoreGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "policy_engine"]
+        {{- else }}
+        args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "policy_engine"]
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchorePolicyEngine.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - name: policy
+          containerPort: {{ .Values.anchorePolicyEngine.service.port }}
+        volumeMounts:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- end }}
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        - name: {{ $component }}-scratch
+          mountPath: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: policy
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: policy
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchorePolicyEngine.resources | nindent 10 }}
+      volumes:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          secret:
+            secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
+        {{- end }}
+        - name: config-volume
+          configMap:
+            name: {{ template "anchore-engine.fullname" . }}
+        - name: {{ $component }}-scratch
+          {{ toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.certStoreSecretName }}
+        - name: certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - name: {{ .Values.cloudsql.serviceAccSecretName }}
+          secret:
+            secretName: {{ .Values.cloudsql.serviceAccSecretName }}
+        {{- end }}
+      {{- with .Values.anchorePolicyEngine.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchorePolicyEngine.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchorePolicyEngine.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "anchore-engine.policy-engine.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchorePolicyEngine.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.anchorePolicyEngine.service.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.anchorePolicyEngine.service.type }}
+  ports:
+    - name: anchore-policy-api
+      port: {{ .Values.anchorePolicyEngine.service.port }}
+      targetPort: {{ .Values.anchorePolicyEngine.service.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}

--- a/stable/anchore-engine/templates/secrets.yaml
+++ b/stable/anchore-engine/templates/secrets.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.anchoreGlobal.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "anchore-engine.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+type: Opaque
+stringData:
+  ANCHORE_ADMIN_PASSWORD: {{ include "anchore-engine.defaultAdminPassword" . | quote }}
+  ANCHORE_DB_PASSWORD: {{ index .Values "postgresql" "postgresPassword" | quote }}
+  {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
+  .feedsDbPassword: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}
+  {{- end }}
+{{- end }}

--- a/stable/anchore-engine/templates/simplequeue_deployment.yaml
+++ b/stable/anchore-engine/templates/simplequeue_deployment.yaml
@@ -1,0 +1,220 @@
+{{- $component := "simplequeue" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "anchore-engine.simplequeue.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreSimpleQueue.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "anchore-engine.fullname" . }}
+      component: {{ $component }}
+  replicas: {{ .Values.anchoreSimpleQueue.replicaCount }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "anchore-engine.fullname" . }}
+        component: {{ $component }}
+        {{- with .Values.anchoreSimpleQueue.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.labels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.anchoreSimpleQueue.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+    {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+      imagePullSecrets:
+      - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+    {{- else }}
+      {{- with .Values.anchoreGlobal.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        command: ["/cloud_sql_proxy"]
+        args:
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
+        volumeMounts:
+        - mountPath: /var/{{ .Values.cloudsql.serviceAccSecretName }}
+          name: {{ .Values.cloudsql.serviceAccSecretName }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+      - name: "{{ .Chart.Name }}-{{ $component }}"
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        image: {{ .Values.anchoreEnterpriseGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- else }}
+        image: {{ .Values.anchoreGlobal.image }}
+        imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "simplequeue"]
+        {{- else }}
+        args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "simplequeue"]
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        - configMapRef:
+            name: {{ template "anchore-engine.fullname" . }}-env
+        env:
+        {{- with .Values.anchoreGlobal.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.anchoreSimpleQueue.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - name: simplequeue
+          containerPort: {{ .Values.anchoreSimpleQueue.service.port }}
+        volumeMounts:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          mountPath: /home/anchore/license.yaml
+          subPath: license.yaml
+        {{- end }}
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          mountPath: /anchore_service_config
+        - name: logs
+          mountPath: /var/log/anchore
+        - name: run
+          mountPath: /var/run/anchore
+        {{- end }}
+        {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
+        - name: certs
+          mountPath: /home/anchore/certs/
+          readOnly: true
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: simplequeue
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: simplequeue
+            {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+            scheme: HTTPS
+            {{- end }}
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          {{ toYaml .Values.anchoreSimpleQueue.resources | nindent 10 }}
+      volumes:
+        {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+        - name: anchore-license
+          secret:
+            secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
+        {{- end }}
+        - name: config-volume
+          configMap:
+            name: {{ template "anchore-engine.fullname" .}}
+        {{- if .Values.anchoreGlobal.openShiftDeployment }}
+        - name: service-config-volume
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.certStoreSecretName }}
+        - name: certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- if .Values.cloudsql.useExistingServiceAcc }}
+        - name: {{ .Values.cloudsql.serviceAccSecretName }}
+          secret:
+            secretName: {{ .Values.cloudsql.serviceAccSecretName }}
+        {{- end }}
+      {{- with .Values.anchoreSimpleQueue.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreSimpleQueue.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreSimpleQueue.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "anchore-engine.simplequeue.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ $component }}
+    {{- with .Values.anchoreSimpleQueue.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.anchoreSimpleQueue.service.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.anchoreSimpleQueue.service.type }}
+  ports:
+    - name: anchore-simplequeue-api
+      port: {{ .Values.anchoreSimpleQueue.service.port }}
+      targetPort: {{ .Values.anchoreSimpleQueue.service.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "anchore-engine.fullname" . }}
+    component: {{ $component }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1,0 +1,819 @@
+# Default values for anchore_engine chart.
+
+# Anchore engine has a dependency on Postgresql, configure here
+postgresql:
+  # To use an external DB or Google CloudSQL in GKE, uncomment & set 'enabled: false'
+  # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
+  # enabled: false
+  postgresUser: anchoreengine
+  postgresPassword: anchore-postgres,123
+  postgresDatabase: anchore
+
+  # Specify an external (already existing) postgres deployment for use.
+  # Set to the host and port. eg. mypostgres.myserver.io:5432
+  externalEndpoint: Null
+
+  # Configure size of the persistent volume used with helm managed chart.
+  # This should be commented out if using an external endpoint.
+  persistence:
+    resourcePolicy: nil
+    size: 20Gi
+
+  # If running on OpenShift - uncomment the image, imageTag & extraEnv values below.
+  # image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+  # imageTag: latest
+  # extraEnv:
+  # - name: POSTGRESQL_USER
+  #   value: anchoreengine
+  # - name: POSTGRESQL_PASSWORD
+  #   value: anchore-postgres,123
+  # - name: POSTGRESQL_DATABASE
+  #   value: anchore
+  # - name: PGUSER
+  #   value: postgres
+  # - name: LD_LIBRARY_PATH
+  #   value: /opt/rh/rh-postgresql96/root/usr/lib64
+  # - name: PATH
+  #   value: /opt/rh/rh-postgresql96/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Google CloudSQL support in GKE via gce-proxy
+cloudsql:
+  # To use CloudSQL in GKE set 'enable: true'
+  enabled: false
+  # set CloudSQL instance: 'project:zone:instancname'
+  instance: ""
+  # Optional existing service account secret to use.
+  # useExistingServiceAcc: false
+  # serviceAccSecretName: service_acc
+  # serviceAccJsonName: for_cloudsql.json
+  image:
+    # set repo and image tag of gce-proxy
+    repository: gcr.io/cloudsql-docker/gce-proxy
+    tag: 1.12
+    pullPolicy: IfNotPresent
+
+# Create an ingress resource for all external anchore engine services (API & Enterprise UI).
+# By default this chart is setup to use the NGINX ingress controller which needs to be installed & configured on your cluster.
+# To utilize a GCE/ALB ingress controller comment out the nginx annotations below, change ingress.class, edit path configurations as per the comments, & set API/UI services to use NodePort.
+ingress:
+  enabled: false
+  labels: {}
+  # Use the following paths for GCE/ALB ingress controller
+  # feedsPath: /v1/feeds/*
+  # apiPath: /v1/*
+  # uiPath: /*
+  # Exposing the feeds API w/ ingress is for special cases only, uncomment feedsPath if external access to the feeds API is needed
+  # feedsPath: /v1/feeds/
+  apiPath: /v1/
+  uiPath: /
+  # uncomment `feedsPath` to add an ingress endpoint for the feeds api
+
+  # Uncomment the following lines to bind on specific hostnames
+  # apiHosts:
+  #   - anchore-api.example.com
+  # uiHosts:
+  #   - anchore-ui.example.com
+  # feedsHosts:
+  #   - anchore-feeds.example.com
+  annotations:
+    # kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.class: nginx
+    # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # kubernetes.io/ingress.allow-http: false
+    # kubernetes.io/tls-acme: true
+  tls: []
+  # Secrets must be manually created in the namespace.
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Global configuration shared by all anchore-engine services.
+anchoreGlobal:
+  # Image used for all anchore engine deployments (excluding enterprise components).
+  image: docker.io/anchore/anchore-engine:v0.7.3
+  imagePullPolicy: IfNotPresent
+  # Set image pull secret name if using an anchore-engine image from a private registry
+  imagePullSecretName:
+
+  # Set this value to True to setup the chart for OpenShift deployment compatibility.
+  openShiftDeployment: False
+
+  # Add additionnal labels to all kubernetes resources
+  labels: {}
+    # app.kubernetes.io/managed-by: Helm
+    # foo: bar
+
+  # Set extra environment variables. These will be set on all containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # Specifies an existing secret to be used for admin and db passwords
+  existingSecret: Null
+
+  # The scratchVolume controls the mounting of an external volume for scratch space for image analysis. Generally speaking
+  # you need to provision 3x the size of the largest image (uncompressed) that you want to analyze for this space.
+  scratchVolume:
+    mountPath: /analysis_scratch
+    details:
+      # Specify volume configuration here
+      emptyDir: {}
+
+  # A secret must be created in the same namespace as anchore-engine is deployed, containing the certificates & public/private keys used for SSL, SAML & custom CAs.
+  # Certs and keys should be added using the file name the certificate is stored at. This secret will be mounted to /home/anchore/certs.
+  certStoreSecretName: Null
+
+  ###
+  # Start of General Anchore Engine Configurations (populates /config/config.yaml)
+  ###
+  # Set where default configs are placed at startup. This must be a writable location for the pod.
+  serviceDir: /anchore_service
+  logLevel: INFO
+  cleanupImages: true
+
+  # Define timeout, in seconds, for image analysis
+  imageAnalyzeTimeoutSeconds: 36000
+
+  # If true, when a user adds an ECR registry with username = awsauto then the system will look for an instance profile to use for auth against the registry
+  allowECRUseIAMRole: false
+
+  # Enable prometheus metrics
+  enableMetrics: false
+
+  # Disable auth on prometheus metrics
+  metricsAuthDisabled: false
+
+  # Sets the password & email address for the default anchore-engine admin user.
+  defaultAdminPassword: foobar
+  defaultAdminEmail: example@email.com
+
+  saml:
+    # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
+    # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
+    secret: Null
+    privateKeyName: Null
+    publicKeyName: Null
+
+  oauthEnabled: false
+  oauthTokenExpirationSeconds: 3600
+
+  # Set this to True to enable storing user passwords only as secure hashes in the db. This can dramatically increase CPU usage if you
+  # don't also use oauth and tokens for internal communications (which requires keys/secret to be configured as well)
+  # WARNING: you should not change this after a system has been initialized as it may cause a mismatch in existing passwords
+  hashedPasswords: false
+
+  # Configure the database connection within anchore-engine & enterprise-ui. This may get split into 2 different configurations based on service utilized.
+  dbConfig:
+    timeout: 120
+    # Use ssl, but the default postgresql config in helm's stable repo does not support ssl on server side, so this should be set for external dbs only.
+    # All ssl dbConfig values are only utilized when ssl=true
+    ssl: false
+    sslMode: verify-full
+    # sslRootCertName is the name of the postgres root CA certificate stored in anchoreGlobal.certStoreSecretName
+    sslRootCertName: Null
+    connectionPoolSize: 30
+    connectionPoolMaxOverflow: 100
+
+  internalServicesSsl:
+    # Enable to force all anchore-engine services to communicate internally using SSL
+    enabled: false
+    # specify whether cert is verfied against the local certifacte bundle (allow self-signed certs if set to false)
+    verifyCerts: false
+    certSecretKeyName: Null
+    certSecretCertName: Null
+
+  # To enable webhooks, set webhooksEnabled: true
+  webhooksEnabled: false
+  # Configure webhook outputs here. The service provides these webhooks for notifying external systems of updates
+  webhooks:
+    # User and password to be set (using HTTP basic auth) on all webhook calls if necessary
+    webhook_user: Null
+    webhook_pass: Null
+    ssl_verify: true
+
+    # Endpoint for general notification delivery. These events are image/tag updates etc. This is globally configured
+    # and updates for all users are sent to the same host but with a different path for each user.
+    # <notification_type>/<userId> are required as documented at end of URI - only hostname:port should be configured.
+    general: {}
+      # url: "http://somehost:9090/<notification_type>/<userId>"
+
+# Configuration for the analyzer pods that perform image analysis
+# There may be many of these analyzers but best practice is to not have more than one per node since analysis
+# is very IO intensive. Use of affinity/anti-affinity rules for scheduling the analyzers is future work.
+anchoreAnalyzer:
+  replicaCount: 1
+  containerPort: 8084
+
+  # Set extra environment variables. These will be set only on analyzer containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # The cycle timer is the interval between checks to the work queue for new jobs
+  cycleTimers:
+    image_analyzer: 5
+
+  # Controls the concurrency of the analyzer itself. Can be configured to process more than one task at a time, but it IO bound, so may not
+  # necessarily be faster depending on hardware. Should test and balance this value vs. number of analyzers for your deployment cluster performance.
+  concurrentTasksPerWorker: 1
+
+  # Image layer caching can be enabled to speed up image downloads before analysis.
+  # This chart sets up a scratch directory for all analyzer pods using the values found at anchoreGlobal.scratchVolume.
+  # When setting anchoreAnalyzer.layerCacheMaxGigabytes, ensure the scratch volume has suffient storage space.
+  # For more info see - https://docs.anchore.com/current/docs/engine/engine_installation/storage/layer_caching/
+  # Enable image layer caching by setting a cache size > 0GB.
+  layerCacheMaxGigabytes: 0
+  configFile:
+    # Anchore analyzer config file
+    #
+    # WARNING - malforming this file can cause the analyzer to fail on all image analysis
+    #
+    # Options for any analyzer module(s) that takes customizable input
+    #
+    # example configuration for the 'retrieve_files' analyzer, if installed
+    retrieve_files:
+      file_list:
+        - '/etc/passwd'
+        # - '/etc/services'
+        # - '/etc/sudoers'
+
+    # example configuration for the 'content_search' analyze, if installed
+    secret_search:
+      match_params:
+        - MAXFILESIZE=10000
+        - STOREONMATCH=n
+      regexp_match:
+        - "AWS_ACCESS_KEY=(?i).*aws_access_key_id( *=+ *).*(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]).*"
+        - "AWS_SECRET_KEY=(?i).*aws_secret_access_key( *=+ *).*(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=]).*"
+        - "PRIV_KEY=(?i)-+BEGIN(.*)PRIVATE KEY-+"
+        - "DOCKER_AUTH=(?i).*\"auth\": *\".+\""
+        - "API_KEY=(?i).*api(-|_)key( *=+ *).*(?<![A-Z0-9])[A-Z0-9]{20,60}(?![A-Z0-9]).*"
+        # - "ALPINE_NULL_ROOT=^root:::0:::::$"
+    # content_search:
+    #   match_params:
+    #     - MAXFILESIZE=10000
+    #   regexp_match:
+    #     - "EXAMPLE_MATCH="
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 4G
+  #  requests:
+  #    cpu: 1
+  #    memory: 1G
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+
+# Pod configuration for the anchore engine api service.
+anchoreApi:
+  replicaCount: 1
+
+  # Set extra environment variables. These will be set on all api containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # kubernetes service configuration for anchore external API
+  service:
+    type: ClusterIP
+    port: 8228
+    annotations: {}
+    label: {}
+
+  # (Optional) Overrides for constructing API URLs.  All values are optional.
+  # external:
+  #   use_tls: true
+  #   hostname: anchore-api.example.com
+  #   port: 8443
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 4G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 1G
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+anchoreCatalog:
+  replicaCount: 1
+
+  # Set extra environment variables. These will be set on all catalog containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # Intervals to run specific events on (seconds)
+  cycleTimers:
+    # Interval to check for an update to a tag
+    image_watcher: 3600
+    # Interval to run a policy evaluation on images with the policy_eval subscription activated.
+    policy_eval: 3600
+    # Interval to run a vulnerability scan on images with the vuln_update subscription activated.
+    vulnerability_scan: 14400
+    # Interval at which the catalog looks for new work to put on the image analysis queue.
+    analyzer_queue: 1
+    # Interval notifications will be processed for state changes
+    notifications: 30
+    # Intervals service state updates are polled for the system status
+    service_watcher: 15
+    # Interval between checks to repo for new tags
+    repo_watcher: 60
+
+  # Event log configuration for webhooks
+  events:
+    notification:
+      enabled: false
+      # Send notifications for events with severity level that matches items in this list
+      level:
+        - error
+        # - info
+
+  archive:
+    compression:
+      enabled: true
+      min_size_kbytes: 100
+    storage_driver:
+      # Valid storage driver names: 'db', 's3', 'swift'
+      name: db
+      config: {}
+
+      # Example S3 Configuration:
+      # name: s3
+      # config:
+      #   # All objects are stored in a single bucket, defined here
+      #   bucket: "anchore-engine-testing"
+      #   # A prefix for keys in the bucket if desired (optional)
+      #   prefix: "internaltest"
+      #   # Create the bucket if it doesn't already exist
+      #   create_bucket: false
+          # Url only needed for non-AWS S3 implementations (e.g. minio). Otherwise, configure the region instead
+      #   #url: "https://s3.amazonaws.com"
+      #   # AWS region to connect to if 'url' not specified, if both are set, then 'url' has precedent
+      #   region: us-west-2
+      #   # For Auth can provide access/secret keys or use 'iamauto' which will use an instance profile or any credentials found in normal aws search paths/metadata service
+      #   access_key: XXXX
+      #   secret_key: YYYY
+      #   iamauto: false
+
+      # Example Minio configuration (basically same as s3 example):
+      # name: s3
+      # config:
+      #   url: http://<minio url>:9000
+      #   bucket: mybucket
+      #   access_key: xxxxxx
+      #   secret_key: yyyyyy
+      #   create_bucket: true
+
+      # Example Swift Configuration:
+      # name: swift
+      # config:
+      #     # Config for swift has a few options, just add the keys and names as used to configure a swiftclient here. All are passed directly to the client impl.
+      #     user: "test:tester"
+      #     key: "testing"
+      #     auth: "http://swift_ephemeral:8080/auth/v1.0"
+      #     # The swift container where data will be stored
+      #     container: "local_test_anchore"
+      #     # Create the container if it is not already present
+      #     create_container: false
+
+  # kubernetes service configuration for anchore catalog api
+  service:
+    type: ClusterIP
+    port: 8082
+    annotations: {}
+    labels: {}
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 2G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 500M
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Pod configuration for the anchore engine policy service.
+anchorePolicyEngine:
+  replicaCount: 1
+
+  # Set extra environment variables. These will be set on all policy engine containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # Intervals to run specific events on (seconds)
+  cycleTimers:
+    # Interval to run a feed sync to get latest cve data
+    feed_sync: 14400
+    # Interval between checks to see if there needs to be a task queued
+    feed_sync_checker: 3600
+
+  # kubernetes service configuration for anchore policy engine api
+  service:
+    type: ClusterIP
+    port: 8087
+    annotations: {}
+    labels: {}
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 4G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 1G
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Pod configuration for the anchore engine simplequeue service.
+anchoreSimpleQueue:
+  replicaCount: 1
+
+  # Set extra environment variables. These will be set on all simplequeue containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # kubernetes service configuration for anchore simplequeue api
+  service:
+    type: ClusterIP
+    port: 8083
+    annotations: {}
+    labels: {}
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 1G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256M
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# This section is used for configuring anchore enterprise.
+anchoreEnterpriseGlobal:
+  enabled: false
+  # Name of kubernetes secret containing your license.yaml file.
+  # Create this secret with the following command - kubectl create secret generic anchore-license --from-file=license.yaml=<PATH TO LICENSE.YAML>
+  licenseSecretName: anchore-enterprise-license
+
+  image: docker.io/anchore/enterprise:v2.3.2
+  imagePullPolicy: IfNotPresent
+  # Name of the kubernetes secret containing your dockerhub creds with access to the anchore enterprise images.
+  # Create this secret with the following command - kubectl create secret docker-registry anchore-dockerhub-creds --docker-server=docker.io --docker-username=<USERNAME> --docker-password=<PASSWORD> --docker-email=<EMAIL_ADDRESS>
+  imagePullSecretName: anchore-enterprise-pullcreds
+
+# Configure the second postgres database instance for the enterprise feeds service.
+# Only utilized if anchoreEnterpriseGlobal.enabled: true
+anchore-feeds-db:
+  # To use an external DB or Google CloudSQL, uncomment & set 'enabled: false'
+  # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
+  # enabled: false
+  postgresUser: anchoreengine
+  postgresPassword: anchore-postgres,123
+  postgresDatabase: anchore-feeds
+
+  # Specify an external (already existing) postgres deployment for use.
+  # Set to the host and port. eg. mypostgres.myserver.io:5432
+  externalEndpoint: Null
+
+  # Configure size of the persitant volume used with helm managed chart.
+  # This should be commented out if using an external endpoint.
+  persistence:
+    resourcePolicy: nil
+    size: 20Gi
+
+  # If running on OpenShift - uncomment the image, imageTag & extraEnv values below.
+  # image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+  # imageTag: latest
+  # extraEnv:
+  # - name: POSTGRESQL_USER
+  #   value: anchoreengine
+  # - name: POSTGRESQL_PASSWORD
+  #   value: anchore-postgres,123
+  # - name: POSTGRESQL_DATABASE
+  #   value: anchore
+  # - name: PGUSER
+  #   value: postgres
+  # - name: LD_LIBRARY_PATH
+  #   value: /opt/rh/rh-postgresql96/root/usr/lib64
+  # - name: PATH
+  #   value: /opt/rh/rh-postgresql96/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Configure & enable the Anchore Enterprise on-prem feeds service.
+anchoreEnterpriseFeeds:
+  # If enabled is set to false, set anchore-feeds-db.enabled to false to ensure that helm doesn't stand up a unneccessary postgres instance.
+  enabled: true
+
+  # Enable github advisory feeds
+  githubDriverEnabled: false
+  # GitHub advisory feeds require a github developer personal access token with no permission scopes selected.
+  githubDriverToken: null
+
+  # Enable microsoft feeds
+  msrcDriverEnabled: false
+  msrcApiKey: null
+  # Uncomment to add MSRC product IDs for generating their feed data, this extends the pre-defined list of product IDs
+  # msrcWhitelist:
+  # - 12345
+
+  # Set extra environment variables. These will be set on all feeds containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # Time delay in seconds between consecutive driver runs for processing data
+  cycleTimers:
+    driver_sync: 7200
+
+  # Configure the database connection within anchore-engine & enterprise-ui. This may get split into 2 different configurations based on service utilized.
+  dbConfig:
+    timeout: 120
+    # Use ssl, but the default postgresql config in helm's stable repo does not support ssl on server side, so this should be set for external dbs
+    ssl: false
+    sslMode: verify-full
+    # Specify path to an additional root CA certificate - this is only utilized if 'ssl: true' is configured.
+    sslRootCertName: Null
+    connectionPoolSize: 30
+    connectionPoolMaxOverflow: 100
+
+  # kubernetes service configuration for anchore feeds service api
+  service:
+    type: ClusterIP
+    port: 8448
+    annotations: {}
+    labels: {}
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 4G
+  #  requests:
+  #    cpu: 1
+  #    memory: 2G
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Configure the Anchore Enterprise role based access control component.
+# This component consists of 2 containers that run as side-cars in the anchore engine api pod.
+anchoreEnterpriseRbac:
+  enabled: true
+
+  # Set extra environment variables. These will be set on all rbac containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # Kubernetes service config - annotations & serviceType configs must be set in anchoreApi
+  # Due to RBAC sharing a service with the general API.
+  service:
+    apiPort: 8229
+    authPort: 8089
+
+  # authResources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 1G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256M
+
+  # managerResources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 1G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256M
+
+# Configure the Anchore Enterprise reporting component.
+anchoreEnterpriseReports:
+  enabled: true
+
+  # Set extra environment variables. These will be set on all rbac containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # GraphiQL is a GUI for editing and testing GraphQL queries and mutations.
+  # Set enable_graphiql to true and open http://<host>:<port>/v1/reports/graphql in a browser for reports API
+  enableGraphql: true
+  # Set enable_data_ingress to true for periodically syncing data from anchore engine into the reports service
+  enableDataIngress: true
+
+  cycleTimers:
+    # images and tags synced every 10 minutes
+    reports_data_load: 600
+    # policy evaluations and vulnerabilities refreshed every 2 hours
+    reports_data_refresh: 7200
+    # metrics generated every hour
+    reports_metrics: 3600
+
+  # Kubernetes service config - annotations & serviceType configs must be set in anchoreApi
+  # Due to Reports sharing a service with the general API.
+  service:
+    port: 8558
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 1G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256M
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Configure the Anchore Enterprise notifications component.
+anchoreEnterpriseNotifications:
+  enabled: true
+
+  # Set extra environment variables. These will be set on all rbac containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  cycleTimers:
+    notifications: 30
+
+  # Kubernetes service config - annotations & serviceType configs must be set in anchoreApi
+  # Due to Reports sharing a service with the general API.
+  service:
+    port: 8668
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 1G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256M
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Configure the Anchore Enterprise UI.
+anchoreEnterpriseUi:
+  # If enabled is set to false, set anchore-ui-redis.enabled to false to ensure that helm doesn't stand up a unneccessary redis instance.
+  enabled: true
+  image: docker.io/anchore/enterprise-ui:v2.3.2
+  imagePullPolicy: IfNotPresent
+
+  # Set extra environment variables. These will be set on all UI containers.
+  extraEnv: []
+    # - name: foo
+    #   value: bar
+
+  # If using LDAPS with a custom CA certificate, add the certificate to the secret specified at anchoreGlobal.certStoreSecretName and specify the name of the cert here
+  ldapsRootCaCertName: Null
+
+  # Specifies whether to trust a reverse proxy when setting secure cookies (via the `X-Forwarded-Proto` header).
+  enableProxy: false
+
+  # Specifies if SSL is enabled in the web app container.
+  enableSsl: false
+
+  # Specifies if a single set of user credentials can be used to start multiple Anchore Enterprise UI sessions; for
+  # example, by multiple users across different systems, or by a single user on a single system across multiple browsers.
+  #
+  # When set to `false`, only one session per credential is permitted at a time, and logging in will invalidate any other
+  # sessions that are using the same set of credentials. Note that setting this property to `false` does not prevent a
+  # single session from being viewed within multiple *tabs* inside the same browser.
+  enableSharedLogin: true
+
+  # The redisFlushdb` key specifies if the Redis datastore containing
+  # user session keys and data is emptied on application startup. If the datastore
+  # is flushed, any users with active sessions will be required to re-authenticate.
+  redisFlushdb: true
+
+  # The (optional) `policy_hub_uri` key specifies the address of a Policy Hub
+  # service. The value must be a string containing a properly-formed 'http' or
+  # 'https' URI, and can be overridden by using the `ANCHORE_POLICY_HUB_URI`
+  # environment variable.
+  #
+  # When this value is set, the Policy Hub component is enabled within the
+  # Policy Manager view (`/policy`). Note that the availability and integrity of
+  # Policy Hub data is determined by this component at run-time when this
+  # component is accessed.
+  policyHubUri: 'http://hub.anchore.io'
+
+  # The (optional) `custom_links` key allows a list of up to 10 external links to
+  # be provided (additional items will be excluded). The top-level `title` key
+  # provided the label for the menu (if present, otherwise the string "Custom
+  # External Links" will be used instead).
+  #
+  #  Each link entry must have a title of greater than 0-length and a valid URI.
+  #  If either item is invalid, the entry will be excluded.
+  #
+  # Uncomment customLinks and specify your custom config as per the example below
+  # customLinks:
+  #   title: Custom External Links
+  #   links:
+  #   - title: Example Link 1
+  #     uri: https://example.com
+  #   - title: Example Link 2
+  #     uri: https://example.com
+  #   - title: Example Link 3
+  #     uri: https://example.com
+  #   - title: Example Link 4
+  #     uri: https://example.com
+  #   - title: Example Link 5
+  #     uri: https://example.com
+  #   - title: Example Link 6
+  #     uri: https://example.com
+  #   - title: Example Link 7
+  #     uri: https://example.com
+  #   - title: Example Link 8
+  #     uri: https://example.com
+  #   - title: Example Link 9
+  #     uri: https://example.com
+  #   - title: Example Link 10
+  #     uri: https://example.com
+
+  # The (optional) `enable_add_repositories` key specifies if repositories can be
+  # added via the application interface by either administrative users or standard
+  # users. In the absence of this key, the default is `True`.
+  #
+  # In the absence of one or all of the properties, the default is also `True`.
+  # Thus, this key and a child key corresponding to an account type must be
+  # explicitly set to `False` for the feature to be disabled for that account.
+  #
+  # Uncomment enableAddRepositories and set the config as per the example below
+  # enableAddRepositories:
+  #   admin: True
+  #   standard: True
+
+  # kubernetes service configuration for anchore UI
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+    labels: {}
+    sessionAffinity: ClientIP
+
+  # resources:
+  #  limits:
+  #    cpu: 1
+  #    memory: 1G
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256M
+
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Anchore Engine Enterprise UI is dependent on redis for storing sessions
+# Only utilized if 'anchoreEnterpriseUi.enabled: true'
+anchore-ui-redis:
+  password: anchore-redis,123
+  cluster:
+    enabled: false
+  persistence:
+    enabled: false
+
+  # To use an external redis endpoint, uncomment to set 'enabled: false'
+  # enabled: false
+
+  # If 'enabled: false', specify an external redis endpoint -
+  # eg redis://:<password>@hostname:6379
+  externalEndpoint: Null


### PR DESCRIPTION
This PR includes the "legacy" anchore-engine chart from the official helm/stable repo. The only differences from the official chart is that the redis dependency has been updated to the latest Bitnami chart, and the postgresql dependent chart has been vendored in to bump the API version to be compatible with k8s v1.16+

Still need to include some documentation in the README about migrating from helm/stable to this new chart repo.

Fixes #15 #16 #33 #34 