### PR TITLE
Fix releases to index.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.0.0-rc.1
         with:
           charts_dir: stable
-          charts_repo_url: https://btodhunter.github.io/anchore-charts
+          charts_repo_url: https://charts.anchore.io
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The deploy action was still referencing the test repo which only had a single version of the admission controller chart. This repo argument determines where the release action pulls the old index.yaml from to append the new release to. 

I have also manually updated the index.yaml found on the gh-pages branch so that the chart repo is once again serving all the old chart versions.

Signed-off-by: Brady Todhunter <bradyt@anchore.com>