### PR TITLE
Helm chart Updated to pass secrets via environment variables.

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: anchore-engine
-version: 1.9.0
+version: 1.9.3
 appVersion: 0.8.1
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/analyzer_deployment.yaml
+++ b/stable/anchore-engine/templates/analyzer_deployment.yaml
@@ -35,8 +35,11 @@ spec:
         {{- with .Values.anchoreGlobal.labels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.anchoreAnalyzer.annotations }}
       annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreAnalyzer.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -83,8 +86,10 @@ spec:
         args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "analyzer"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:

--- a/stable/anchore-engine/templates/api_deployment.yaml
+++ b/stable/anchore-engine/templates/api_deployment.yaml
@@ -35,8 +35,11 @@ spec:
         {{- with .Values.anchoreGlobal.labels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.anchoreApi.annotations }}
       annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreApi.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -83,8 +86,10 @@ spec:
         args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "apiext"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:
@@ -98,11 +103,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- if not .Values.inject_secrets_via_env }}
         - name: ANCHORE_CLI_PASS
           valueFrom:
             secretKeyRef:
               name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
               key: ANCHORE_ADMIN_PASSWORD
+        {{- end }}
         ports:
         - containerPort: {{ .Values.anchoreApi.service.port }}
           name: external-api
@@ -159,8 +166,10 @@ spec:
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
         args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "rbac_manager"]
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:
@@ -227,8 +236,10 @@ spec:
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
         args: ["anchore-enterprise-manager", "service", "start", "--no-auto-upgrade", "rbac_authorizer"]
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:
@@ -298,8 +309,10 @@ spec:
         - containerPort: {{ .Values.anchoreEnterpriseReports.service.port }}
           name: reports-api
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ template "anchore-engine.fullname" . }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:
@@ -368,8 +381,10 @@ spec:
         - containerPort: {{ .Values.anchoreEnterpriseNotifications.service.port }}
           name: notifi-api
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ template "anchore-engine.fullname" . }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:

--- a/stable/anchore-engine/templates/catalog_deployment.yaml
+++ b/stable/anchore-engine/templates/catalog_deployment.yaml
@@ -35,8 +35,11 @@ spec:
         {{- with .Values.anchoreGlobal.labels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.anchoreCatalog.annotations }}
       annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreCatalog.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -83,8 +86,10 @@ spec:
         args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "catalog"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:

--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -18,6 +18,10 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.anchoreGlobal.securityContext }}
       securityContext:
@@ -48,8 +52,10 @@ spec:
         args: ["/bin/bash", "-c", "anchore-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -36,8 +36,11 @@ spec:
         {{- with .Values.anchoreGlobal.labels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.anchoreEnterpriseFeeds.annotations }}
       annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreEnterpriseFeeds.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -71,8 +74,10 @@ spec:
         - containerPort: {{ .Values.anchoreEnterpriseFeeds.service.port }}
           name: feeds-api
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}-env
         env:
@@ -82,11 +87,13 @@ spec:
         {{- with .Values.anchoreEnterpriseFeeds.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if not .Values.inject_secrets_via_env }}
         - name: ANCHORE_DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "anchore-engine.fullname" . }}
               key: .feedsDbPassword
+        {{- end }}
         - name: ANCHORE_POD_NAME
           valueFrom:
             fieldRef:

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -19,6 +19,10 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.anchoreGlobal.securityContext }}
       securityContext:
@@ -37,8 +41,10 @@ spec:
         args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}-env
         env:

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -40,8 +40,11 @@ spec:
         {{- with .Values.anchoreGlobal.labels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.anchoreEnterpriseUi.annotations }}
       annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreEnterpriseUi.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -19,6 +19,10 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.anchoreGlobal.securityContext }}
       securityContext:
@@ -37,8 +41,10 @@ spec:
         args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:

--- a/stable/anchore-engine/templates/policy_engine_deployment.yaml
+++ b/stable/anchore-engine/templates/policy_engine_deployment.yaml
@@ -35,8 +35,11 @@ spec:
         {{- with .Values.anchoreGlobal.labels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.anchorePolicyEngine.annotations }}
       annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchorePolicyEngine.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -83,8 +86,10 @@ spec:
         args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "policy_engine"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:

--- a/stable/anchore-engine/templates/simplequeue_deployment.yaml
+++ b/stable/anchore-engine/templates/simplequeue_deployment.yaml
@@ -35,8 +35,11 @@ spec:
         {{- with .Values.anchoreGlobal.labels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.anchoreSimpleQueue.annotations }}
       annotations:
+      {{- with .Values.anchoreGlobal.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.anchoreSimpleQueue.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -83,8 +86,10 @@ spec:
         args: ["anchore-manager", "service", "start", "--no-auto-upgrade", "simplequeue"]
         {{- end }}
         envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
             name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
         env:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -103,6 +103,12 @@ anchoreGlobal:
     # app.kubernetes.io/managed-by: Helm
     # foo: bar
 
+  # Add common annotations to set on all pods. Useful expecially when inject secrets directly into pods as ENV from vault via mutation-webhook-injection method.
+  # Ref: https://banzaicloud.com/docs/bank-vaults/mutating-webhook/
+  annotations: {}
+    # vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
+    # vault.security.banzaicloud.io/vault-tls-secret: "vault-tls"
+
   # Set extra environment variables. These will be set on all containers.
   extraEnv: []
     # - name: foo
@@ -841,3 +847,7 @@ anchore-ui-redis:
   # If 'enabled: false', specify an external redis endpoint -
   # eg redis://:<password>@hostname:6379
   externalEndpoint: Null
+
+# To inject secrets ( credentails data ) via env, rather k8s secrets please set this flag to true.
+# This feature will be useful, especially to inject secrets directly into k8s pods from hashicorp vault
+# inject_secrets_via_env: false


### PR DESCRIPTION
Hi, I updated to pass the DB credentials as env variables rather than k8s secrets. Our intension is to directly inject secrets into k8s pods from the Hashicorp vault using mutating webhooks ( Ref: https://banzaicloud.com/blog/inject-secrets-into-pods-vault-revisited).
We already deployed vault in the same k8s cluster and create secrets in the vault. In order to mutating webhook to inject secrets into pods, all pods should contain certain annotations, and we have to pass the env vault in vault format

for example, with this version code if you pass variables like below, then it will set below annotations on all pods and eventually when the pod starts vault will inject secrets into them as env variables (Ref: https://github.com/banzaicloud/bank-vaults/tree/master/charts/vault-secrets-webhook)

anchoreGlobal:
  annotations:
    vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
    vault.security.banzaicloud.io/vault-role: "secrets_access" 
    vault.security.banzaicloud.io/vault-tls-secret: "vault-tls"
  extraEnv:
    # https://docs.anchore.com/current/docs/engine/engine_installation/configuration/network_proxies/
    - name: http_proxy
      value: http://corporateproxy:3128
    - name: https_proxy
      value: http://corporateproxy:3128
    - name: no_proxy
      value: "localhost,127.0.0.1"
    - name: ANCHORE_DB_HOST
      value: <db endpoint>
    - name: ANCHORE_DB_PASSWORD
      value: "vault:secret/data/anchore/db_password#ANCHORE_DB_PASSWORD"
    - name: ANCHORE_CLI_PASS
      value: "vault:secret/data/anchore/db_password#ANCHORE_DB_PASSWORD"
    - name: ANCHORE_APPDB_URI
      value: "vault:secret/data/anchore/appdb_uri#ANCHORE_APPDB_URI"
    - name: ANCHORE_ADMIN_PASSWORD
      value: "vault:secret/data/anchore/admin_password#ANCHORE_ADMIN_PASSWORD"


Regards,
Kishor.