### PR TITLE
Fix endpoint selector

### DIFF
--- a/stable/anchore-admission-controller/Chart.yaml
+++ b/stable/anchore-admission-controller/Chart.yaml
@@ -2,7 +2,11 @@ name: anchore-admission-controller
 description: A kubernetes admission controller for validating and mutating webhooks that operates against Anchore Engine to make access decisions and annotations
 apiVersion: v1
 appVersion: 0.2.2
+<<<<<<< HEAD
 version: 0.2.9
+=======
+version: 0.2.11
+>>>>>>> afbea4c... fix service selector
 home: https://github.com/anchore/kubernetes-admission-controller
 maintainers:
   - name: zhill

--- a/stable/anchore-admission-controller/Chart.yaml
+++ b/stable/anchore-admission-controller/Chart.yaml
@@ -2,11 +2,7 @@ name: anchore-admission-controller
 description: A kubernetes admission controller for validating and mutating webhooks that operates against Anchore Engine to make access decisions and annotations
 apiVersion: v1
 appVersion: 0.2.2
-<<<<<<< HEAD
-version: 0.2.9
-=======
-version: 0.2.11
->>>>>>> afbea4c... fix service selector
+version: 0.2.10
 home: https://github.com/anchore/kubernetes-admission-controller
 maintainers:
   - name: zhill

--- a/stable/anchore-admission-controller/templates/service.yaml
+++ b/stable/anchore-admission-controller/templates/service.yaml
@@ -11,5 +11,5 @@ spec:
     protocol: TCP
     name: {{ .Values.service.name }}
   selector:
-    app: {{ template "anchore-admission-controller.name" . }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "anchore-admission-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Fixes wrong endpoint selector (see below) causing missing endpoint for admission controller

```
kr@KRMB anchore-admission-controller % helm pull anchore/anchore-admission-controller --version 0.2.9

kr@KRMB anchore-admission-controller % helm template aac anchore-admission-controller-0.2.9.tgz --namespace anchore --include-crds --values values.yaml --output-dir .
____output stripped____

kr@KRMB anchore-admission-controller % cat anchore-admission-controller/templates/service.yaml
---
# Source: anchore-admission-controller/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: aac-anchore-admission-controller
  labels:
    app.kubernetes.io/name: anchore-admission-controller
    helm.sh/chart: anchore-admission-controller-0.2.9
    app.kubernetes.io/instance: aac
    app.kubernetes.io/version: "0.2.2"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
  - port: 443
    targetPort: 443
    protocol: TCP
    name: anchoreadmissioncontroller
  selector:       ### This selector is incorrect ###
    app: anchore-admission-controller
    release: aac



kr@KRMB anchore-admission-controller % cat anchore-admission-controller/templates/deployment.yaml 
---
# Source: anchore-admission-controller/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: aac-anchore-admission-controller
  labels:
    app.kubernetes.io/name: anchore-admission-controller
    helm.sh/chart: anchore-admission-controller-0.2.9
    app.kubernetes.io/instance: aac
    app.kubernetes.io/version: "0.2.2"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: anchore-admission-controller
      app.kubernetes.io/instance: aac
  template:
    metadata:
      labels:
        app.kubernetes.io/name: anchore-admission-controller
        helm.sh/chart: anchore-admission-controller-0.2.9
        app.kubernetes.io/instance: aac
        app.kubernetes.io/version: "0.2.2"
        app.kubernetes.io/managed-by: Helm
    spec:
____ output stripped ____
```