### PR TITLE
Add extraEnv support for init pod

### DIFF
--- a/stable/anchore-admission-controller/Chart.yaml
+++ b/stable/anchore-admission-controller/Chart.yaml
@@ -2,7 +2,7 @@ name: anchore-admission-controller
 description: A kubernetes admission controller for validating and mutating webhooks that operates against Anchore Engine to make access decisions and annotations
 apiVersion: v1
 appVersion: 0.2.2
-version: 0.2.10
+version: 0.2.11
 home: https://github.com/anchore/kubernetes-admission-controller
 maintainers:
   - name: zhill

--- a/stable/anchore-admission-controller/README.md
+++ b/stable/anchore-admission-controller/README.md
@@ -99,7 +99,7 @@ It will remove kubernetes objects which are not removed by a helm delete. Pass t
 |---|---|---|---|
 |requestAnalysis | boolean | true | Ask anchore to analyze an image that isn't already analyzed
 |---|---|---|---|
-|extraEnv | array | [] | Define custom environment variables to pass to init-ca pod |
+|initCa.extraEnv | array | [] | Define custom environment variables to pass to init-ca pod |
 |---|---|---|---|
 
 ## Updating configuration

--- a/stable/anchore-admission-controller/README.md
+++ b/stable/anchore-admission-controller/README.md
@@ -99,6 +99,8 @@ It will remove kubernetes objects which are not removed by a helm delete. Pass t
 |---|---|---|---|
 |requestAnalysis | boolean | true | Ask anchore to analyze an image that isn't already analyzed
 |---|---|---|---|
+|extraEnv | array | [] | Define custom environment variables to pass to init-ca pod |
+|---|---|---|---|
 
 ## Updating configuration
 

--- a/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
+++ b/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
@@ -32,7 +32,7 @@ spec:
         - name: init-ca-script
           mountPath: /scripts
         env:
-          {{- with .Values.extraEnv }}
+          {{- with .Values.initCa.extraEnv }}
           {{- toYaml . | nindent 8 }}
           {{- end }}
 

--- a/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
+++ b/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
@@ -35,3 +35,4 @@ spec:
           {{- with .Values.extraEnv }}
           {{- toYaml . | nindent 8 }}
           {{- end }}
+

--- a/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
+++ b/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
@@ -31,3 +31,7 @@ spec:
         volumeMounts:
         - name: init-ca-script
           mountPath: /scripts
+        env:
+          {{- with .Values.extraEnv }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}

--- a/stable/anchore-admission-controller/values.yaml
+++ b/stable/anchore-admission-controller/values.yaml
@@ -80,7 +80,9 @@ credentials: {}
   # - username: user2
   #   password: password2
 
-# Define custom environment variables to pass to init-ca pod
-extraEnv: []
-  # - name: FOO
-  # value: "bar"
+# Settings related to init-ca pod
+initCA:
+  # Define custom environment variables to pass to init-ca pod
+  extraEnv: []
+    # - name: FOO
+    # value: "bar"

--- a/stable/anchore-admission-controller/values.yaml
+++ b/stable/anchore-admission-controller/values.yaml
@@ -81,7 +81,7 @@ credentials: {}
   #   password: password2
 
 # Settings related to init-ca pod
-initCA:
+initCa:
   # Define custom environment variables to pass to init-ca pod
   extraEnv: []
     # - name: FOO

--- a/stable/anchore-admission-controller/values.yaml
+++ b/stable/anchore-admission-controller/values.yaml
@@ -79,3 +79,8 @@ credentials: {}
   #   password: password1
   # - username: user2
   #   password: password2
+
+# Define custom environment variables to pass to init-ca pod
+extraEnv: []
+  # - name: FOO
+  # value: "bar"


### PR DESCRIPTION
Allows passing environment variables to init-ca pod. Useful when k8s nodes are behind a proxy.