### PR TITLE
Add passing of dbConfig.engineArgs in enterprise configmap

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.10.2
+version: 1.10.3
 appVersion: 0.8.2
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -72,6 +72,10 @@ data:
           ssl: false
         db_pool_size: {{ .Values.anchoreGlobal.dbConfig.connectionPoolSize }}
         db_pool_max_overflow: {{ .Values.anchoreGlobal.dbConfig.connectionPoolMaxOverflow }}
+        {{- with .Values.anchoreGlobal.dbConfig.engineArgs }}
+        db_engine_args:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 
     services:
       {{- if .Values.anchoreEnterpriseRbac.enabled }}


### PR DESCRIPTION
The global DB configuration is used in this file but the value of
'engineArgs' wasn't passed. This change adds 'engineArgs' to the
DB configuration.