### PR TITLE
Allow upgrade Jobs to have Annotations

### DIFF
--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -22,6 +22,9 @@ spec:
       {{- with .Values.anchoreGlobal.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.anchoreEngineUpgradeJob.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.anchoreGlobal.securityContext }}
       securityContext:

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -23,6 +23,9 @@ spec:
       {{- with .Values.anchoreGlobal.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.anchoreEnterpriseFeedsUpgradeJob.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.anchoreGlobal.securityContext }}
       securityContext:

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -23,6 +23,9 @@ spec:
       {{- with .Values.anchoreGlobal.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.anchoreEnterpriseEngineUpgradeJob.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.anchoreGlobal.securityContext }}
       securityContext:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -529,6 +529,7 @@ anchoreEngineUpgradeJob:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  annotations: {}
 
 # This section is used for configuring anchore enterprise.
 anchoreEnterpriseGlobal:
@@ -644,6 +645,7 @@ anchoreEnterpriseFeedsUpgradeJob:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  annotations: {}
 
 # Configure the Anchore Enterprise role based access control component.
 # This component consists of 2 containers that run as side-cars in the anchore engine api pod.
@@ -887,6 +889,7 @@ anchoreEnterpriseEngineUpgradeJob:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  annotations: {}
 
 # To inject secrets ( credentails data ) via env, rather k8s secrets please set this flag to true.
 # This feature will be useful, especially to inject secrets directly into k8s pods from hashicorp vault


### PR DESCRIPTION
In certain deployments, it is important to have control over the
annotations associated with an Upgrade Deployment. For example, if
primarily Fargate Pods are used in AWS, the upgrade jobs might need to
be run in EC2 context in order to speed up the helm upgrade process.

Signed-off-by: Adam Wallis <adam.wallis@gmail.com>