### PR TITLE
Use k8s secret for SAML shared secret

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.11.0
+version: 1.11.1
 appVersion: 0.9.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -99,7 +99,7 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      secret: {{ .Values.anchoreGlobal.saml.secret }}
+      secret: ${ANCHORE_SAML_SECRET}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}
       {{- end }}

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -99,7 +99,9 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
+      {{- if .Values.anchoreGlobal.saml.secret }}
       secret: ${ANCHORE_SAML_SECRET}
+      {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}
       {{- end }}

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -41,7 +41,9 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
+      {{- if .Values.anchoreGlobal.saml.secret }}
       secret: ${ANCHORE_SAML_SECRET}
+      {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}
       {{- end }}

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -41,7 +41,7 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      secret: {{ .Values.anchoreGlobal.saml.secret }}
+      secret: ${ANCHORE_SAML_SECRET}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}
       {{- end }}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -33,7 +33,7 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      secret: {{ .Values.anchoreGlobal.saml.secret }}
+      secret: ${ANCHORE_SAML_SECRET}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}
       {{- end }}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -33,7 +33,9 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
+      {{- if .Values.anchoreGlobal.saml.secret }}
       secret: ${ANCHORE_SAML_SECRET}
+      {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}
       {{- end }}

--- a/stable/anchore-engine/templates/secrets.yaml
+++ b/stable/anchore-engine/templates/secrets.yaml
@@ -18,4 +18,7 @@ stringData:
   {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
   .feedsDbPassword: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}
   {{- end }}
+  {{- if .Values.anchoreGlobal.saml.secret }}
+  ANCHORE_SAML_SECRET: {{ .Values.anchoreGlobal.saml.secret }}
+  {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/secrets.yaml
+++ b/stable/anchore-engine/templates/secrets.yaml
@@ -18,7 +18,7 @@ stringData:
   {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
   .feedsDbPassword: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}
   {{- end }}
-  {{- if .Values.anchoreGlobal.saml.secret }}
-  ANCHORE_SAML_SECRET: {{ .Values.anchoreGlobal.saml.secret }}
+  {{- with .Values.anchoreGlobal.saml.secret }}
+  ANCHORE_SAML_SECRET: {{ . }}
   {{- end }}
 {{- end }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -173,9 +173,11 @@ anchoreGlobal:
   defaultAdminEmail: example@email.com
 
   saml:
-    # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
+    # Locations for keys used for signing and encryption. Only one of 'secret' or 'privateKeyName'/'publicKeyName' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     secret: Null
+    # If set to true, use the secret specified in anchoreGlobal.existingSecret to set the ANCHORE_SAML_SECRET env variable
+    useExistingSecret: false
     privateKeyName: Null
     publicKeyName: Null
 


### PR DESCRIPTION
Uses k8s secrets for storing SAML secret, which is mounted as ENV vars for running pods. Replacing hard coded value into the config.

fixes #60 

Signed-off-by: Brady Todhunter <bradyt@anchore.com>