### PR TITLE
Make secrets more consistent

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.11.1
+version: 1.11.2
 appVersion: 0.9.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -57,9 +57,9 @@ data:
     credentials:
       database:
         {{- if .Values.anchoreEnterpriseFeeds.dbConfig.ssl }}
-        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreEnterpriseFeeds.dbConfig.sslRootCertName }}"
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreEnterpriseFeeds.dbConfig.sslRootCertName }}"
         {{- else }}
-        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
         {{- end }}
         db_connect_args:
           timeout: {{ .Values.anchoreEnterpriseFeeds.dbConfig.timeout }}
@@ -103,7 +103,7 @@ data:
             # rubygem data comes packaged as a PostgreSQL dump file. gem driver loads the pg dump and normalizes the data.
             # To enable gem driver comment the enabled property and uncomment the db_connect property.
             enabled: {{ default "false" .Values.anchoreEnterpriseFeeds.gemDriverEnabled }}
-            db_connect: {{ default "'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/gems'" .Values.anchoreEnterpriseFeeds.gemDbEndpoint }}
+            db_connect: {{ default "'postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/gems'" .Values.anchoreEnterpriseFeeds.gemDbEndpoint }}
           amzn:
             enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.amazonDriverEnabled }}
           centos:

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -101,13 +101,6 @@ spec:
         {{- with .Values.anchoreEnterpriseFeeds.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if not .Values.inject_secrets_via_env }}
-        - name: ANCHORE_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "anchore-engine.fullname" . }}
-              key: .feedsDbPassword
-        {{- end }}
         - name: ANCHORE_POD_NAME
           valueFrom:
             fieldRef:

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -39,9 +39,9 @@ spec:
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-        args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{ .Values.anchoreGlobal.dbConfig.sslMode }}\\&sslrootcert=/home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask"]
+        args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{ .Values.anchoreGlobal.dbConfig.sslMode }}\\&sslrootcert=/home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask"]
         {{- else }}
-        args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask"]
+        args: ["/bin/bash", "-c", "anchore-enterprise-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask"]
         {{- end }}
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}
@@ -57,11 +57,6 @@ spec:
         {{- with .Values.anchoreEnterpriseFeeds.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        - name: ANCHORE_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "anchore-engine.fullname" . }}
-              key: .feedsDbPassword
         {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
         volumeMounts:
         - name: certs

--- a/stable/anchore-engine/templates/secrets.yaml
+++ b/stable/anchore-engine/templates/secrets.yaml
@@ -16,7 +16,7 @@ stringData:
   ANCHORE_ADMIN_PASSWORD: {{ include "anchore-engine.defaultAdminPassword" . | quote }}
   ANCHORE_DB_PASSWORD: {{ index .Values "postgresql" "postgresPassword" | quote }}
   {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
-  .feedsDbPassword: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}
+  ANCHORE_FEEDS_DB_PASSWORD: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}
   {{- end }}
   {{- with .Values.anchoreGlobal.saml.secret }}
   ANCHORE_SAML_SECRET: {{ . }}


### PR DESCRIPTION
Use environment variables in the anchore config.yaml file for feeds DB connection endpoint. This allows the feeds service to use the same mechanism for existing secrets as other deployments in the chart.

fixes #92 & #52