### PR TITLE
use init job to set env vars in UI configuration. 

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.11.1
+version: 1.11.3
 appVersion: 0.9.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/enterprise_ui_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_configmap.yaml
@@ -1,9 +1,8 @@
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseUi.enabled -}}
 {{- $component := "enterprise-ui" -}}
 
-# Using a secret until UI app supports ENV vars inside the config file. Redis password is included in config.
-kind: Secret
 apiVersion: v1
+kind: ConfigMap
 metadata:
   name: {{ include "anchore-engine.enterprise-ui.fullname" . | quote }}
   labels:
@@ -15,8 +14,7 @@ metadata:
     {{- with .Values.anchoreGlobal.labels }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-type: Opaque
-stringData:
+data:
   config-ui.yaml: |
     {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
     engine_uri: 'https://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreApi.service.port }}/v1'
@@ -26,7 +24,7 @@ stringData:
     {{- if and (index .Values "anchore-ui-redis" "externalEndpoint") (not (index .Values "anchore-ui-redis" "enabled")) }}
     redis_uri: '{{ index .Values "anchore-ui-redis" "externalEndpoint" }}'
     {{- else }}
-    redis_uri: 'redis://:{{ index .Values "anchore-ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379'
+    redis_uri: 'redis://:${ANCHORE_REDIS_PASSWORD}@{{ template "redis.fullname" . }}-master:6379'
     {{- end }}
   {{- if .Values.anchoreEnterpriseRbac.enabled }}
     {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
@@ -49,14 +47,10 @@ stringData:
     notifications_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseNotifications.service.port}}/v1'
     {{- end }}
   {{- end }}
-    {{- if and (and .Values.postgresql.externalEndpoint (not .Values.postgresql.enabled)) .Values.anchoreGlobal.dbConfig.ssl }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ .Values.postgresql.externalEndpoint }}/{{ .Values.postgresql.postgresDatabase }}?ssl=verify-full'
-    {{- else if and .Values.postgresql.externalEndpoint (not .Values.postgresql.enabled) }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ .Values.postgresql.externalEndpoint }}/{{ .Values.postgresql.postgresDatabase }}'
-    {{- else if and (index .Values "cloudsql" "enabled") (not (index .Values "postgresql" "enabled")) }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@localhost:5432/{{ .Values.postgresql.postgresDatabase }}'
+    {{- if .Values.anchoreGlobal.dbConfig.ssl }}
+    appdb_uri: 'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?ssl=verify-full'
     {{- else }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ template "postgres.fullname" . }}:5432/{{ .Values.postgresql.postgresDatabase }}'
+    appdb_uri: 'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}'
     {{- end }}
     license_path: '/home/anchore/'
     enable_ssl: {{ .Values.anchoreEnterpriseUi.enableSsl }}

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -54,6 +54,28 @@ spec:
       {{- end }}
       imagePullSecrets:
       - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+      initContainers:
+        - name: config-generator
+          image: alpine:latest
+          envFrom:
+          {{- if not .Values.inject_secrets_via_env }}
+          - secretRef:
+              name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+          {{- end }}
+          - configMapRef:
+              name: {{ template "anchore-engine.fullname" . }}-env
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+            - name: anchore-ui-config
+              mountPath: /config/config-ui-vars.yaml
+              subPath: config-ui.yaml
+          command:
+            - sh
+            - -c
+            - (apk add gettext && cat /config/config-ui-vars.yaml | envsubst > /config/config-ui.yaml && chgrp {{ .Values.anchoreGlobal.securityContext.fsGroup }} /config/config-ui.yaml)
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy
@@ -96,9 +118,8 @@ spec:
         - name: anchore-license
           mountPath: /home/anchore/license.yaml
           subPath: license.yaml
-        - name: anchore-ui-config
-          mountPath: /config/config-ui.yaml
-          subPath: config-ui.yaml
+        - name: config-volume
+          mountPath: /config
         {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
         - name: certs
           mountPath: /home/anchore/certs/
@@ -127,8 +148,10 @@ spec:
         secret:
           secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
       - name: anchore-ui-config
-        secret:
-          secretName: {{ template "anchore-engine.enterprise-ui.fullname" . }}
+        configMap:
+          name: {{ template "anchore-engine.enterprise-ui.fullname" . }}
+      - name: config-volume
+        emptyDir: {}
       {{- with .Values.anchoreGlobal.certStoreSecretName }}
       - name: certs
         secret:


### PR DESCRIPTION
This allows for using existing k8s secrets like all other deployments.

Not convinced an init job is the right solution for this. ENV var interpolation is on the development agenda for the UI, however there is not a timeline for this feature implementation yet.

fixes #91 

Signed-off-by: Brady Todhunter <bradyt@anchore.com>