### PR TITLE
Allow configmaps to read saml.useExistingSecret flag

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.11.2
+version: 1.11.3
 appVersion: 0.9.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -99,10 +99,8 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      {{- if .Values.anchoreGlobal.saml.useExistingSecret  }}
+      {{- if or .Values.anchoreGlobal.saml.secret .Values.anchoreGlobal.saml.useExistingSecret }}
       secret: ${ANCHORE_SAML_SECRET}
-      {{- else }}
-      secret: {{ .Values.anchoreGlobal.saml.secret }}
       {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -99,8 +99,10 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      {{- if .Values.anchoreGlobal.saml.secret }}
+      {{- if .Values.anchoreGlobal.saml.useExistingSecret  }}
       secret: ${ANCHORE_SAML_SECRET}
+      {{- else }}
+      secret: {{ .Values.anchoreGlobal.saml.secret }}
       {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -41,10 +41,8 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      {{- if .Values.anchoreGlobal.saml.useExistingSecret  }}
+      {{- if or .Values.anchoreGlobal.saml.secret .Values.anchoreGlobal.saml.useExistingSecret }}
       secret: ${ANCHORE_SAML_SECRET}
-      {{- else }}
-      secret: {{ .Values.anchoreGlobal.saml.secret }}
       {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -41,8 +41,10 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      {{- if .Values.anchoreGlobal.saml.secret }}
+      {{- if .Values.anchoreGlobal.saml.useExistingSecret  }}
       secret: ${ANCHORE_SAML_SECRET}
+      {{- else }}
+      secret: {{ .Values.anchoreGlobal.saml.secret }}
       {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -33,8 +33,10 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      {{- if .Values.anchoreGlobal.saml.secret }}
+      {{- if .Values.anchoreGlobal.saml.useExistingSecret }}
       secret: ${ANCHORE_SAML_SECRET}
+      {{- else }}
+      secret: {{ .Values.anchoreGlobal.saml.secret }}
       {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -33,10 +33,8 @@ data:
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.
     keys:
-      {{- if .Values.anchoreGlobal.saml.useExistingSecret }}
+      {{- if or .Values.anchoreGlobal.saml.secret .Values.anchoreGlobal.saml.useExistingSecret }}
       secret: ${ANCHORE_SAML_SECRET}
-      {{- else }}
-      secret: {{ .Values.anchoreGlobal.saml.secret }}
       {{- end }}
       {{- with .Values.anchoreGlobal.saml.publicKeyName }}
       public_key_path: /home/anchore/certs/{{- . }}


### PR DESCRIPTION
There is currently a bug that requires the saml.secret value to be set
regardless of the value of saml.useExistingSecret. This changes
addresses this issue.

fixes: https://github.com/anchore/anchore-charts/issues/108

Signed-off-by: Adam Wallis <adam.wallis@gmail.com>