### PR TITLE
UI allow existing secrets

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.11.3
+version: 1.11.4
 appVersion: 0.9.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -139,3 +139,17 @@ Return Anchore Engine default admin password
     {{- randAlphaNum 32 -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create database hostname string from supplied values file. Used for the enterprise-ui ANCHORE_APPDB_URI environment variable secret
+*/}}
+{{- define "db-hostname" }}
+  {{- if and (index .Values "postgresql" "externalEndpoint") (not (index .Values "postgresql" "enabled")) }}
+    {{- print ( index .Values "postgresql" "externalEndpoint" | quote ) }}
+  {{- else if and (index .Values "cloudsql" "enabled") (not (index .Values "postgresql" "enabled")) }}
+    {{- print "localhost:5432" }}
+  {{- else }}
+    {{- $db_host := include "postgres.fullname" . }}
+    {{- printf "%s:5432" $db_host -}}
+  {{- end }}
+{{- end }}

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -90,7 +90,7 @@ spec:
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
-            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+            name: {{ default (include "anchore-engine.enterprise-feeds.fullname" .) .Values.anchoreGlobal.existingSecret }}
         {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}-env

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -90,7 +90,7 @@ spec:
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
-            name: {{ default (include "anchore-engine.enterprise-feeds.fullname" .) .Values.anchoreGlobal.existingSecret }}
+            name: {{ default (include "anchore-engine.enterprise-feeds.fullname" .) .Values.anchoreEnterpriseFeeds.existingSecret }}
         {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}-env

--- a/stable/anchore-engine/templates/enterprise_ui_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_configmap.yaml
@@ -1,9 +1,8 @@
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseUi.enabled -}}
 {{- $component := "enterprise-ui" -}}
 
-# Using a secret until UI app supports ENV vars inside the config file. Redis password is included in config.
-kind: Secret
 apiVersion: v1
+kind: ConfigMap
 metadata:
   name: {{ include "anchore-engine.enterprise-ui.fullname" . | quote }}
   labels:
@@ -15,8 +14,7 @@ metadata:
     {{- with .Values.anchoreGlobal.labels }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-type: Opaque
-stringData:
+data:
   config-ui.yaml: |
     {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
     engine_uri: 'https://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreApi.service.port }}/v1'
@@ -26,7 +24,7 @@ stringData:
     {{- if and (index .Values "anchore-ui-redis" "externalEndpoint") (not (index .Values "anchore-ui-redis" "enabled")) }}
     redis_uri: '{{ index .Values "anchore-ui-redis" "externalEndpoint" }}'
     {{- else }}
-    redis_uri: 'redis://:{{ index .Values "anchore-ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379'
+    redis_uri: 'redis://:${ANCHORE_REDIS_PASSWORD}@{{ template "redis.fullname" . }}-master:6379'
     {{- end }}
   {{- if .Values.anchoreEnterpriseRbac.enabled }}
     {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
@@ -49,14 +47,10 @@ stringData:
     notifications_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseNotifications.service.port}}/v1'
     {{- end }}
   {{- end }}
-    {{- if and (and .Values.postgresql.externalEndpoint (not .Values.postgresql.enabled)) .Values.anchoreGlobal.dbConfig.ssl }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ .Values.postgresql.externalEndpoint }}/{{ .Values.postgresql.postgresDatabase }}?ssl=verify-full'
-    {{- else if and .Values.postgresql.externalEndpoint (not .Values.postgresql.enabled) }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ .Values.postgresql.externalEndpoint }}/{{ .Values.postgresql.postgresDatabase }}'
-    {{- else if and (index .Values "cloudsql" "enabled") (not (index .Values "postgresql" "enabled")) }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@localhost:5432/{{ .Values.postgresql.postgresDatabase }}'
+    {{- if .Values.anchoreGlobal.dbConfig.ssl }}
+    appdb_uri: 'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?ssl=verify-full'
     {{- else }}
-    appdb_uri: 'postgresql://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ template "postgres.fullname" . }}:5432/{{ .Values.postgresql.postgresDatabase }}'
+    appdb_uri: 'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}'
     {{- end }}
     license_path: '/home/anchore/'
     enable_ssl: {{ .Values.anchoreEnterpriseUi.enableSsl }}

--- a/stable/anchore-engine/templates/enterprise_ui_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_configmap.yaml
@@ -21,11 +21,8 @@ data:
     {{- else }}
     engine_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreApi.service.port }}/v1'
     {{- end }}
-    {{- if and (index .Values "anchore-ui-redis" "externalEndpoint") (not (index .Values "anchore-ui-redis" "enabled")) }}
-    redis_uri: '{{ index .Values "anchore-ui-redis" "externalEndpoint" }}'
-    {{- else }}
-    redis_uri: 'redis://:${ANCHORE_REDIS_PASSWORD}@{{ template "redis.fullname" . }}-master:6379'
-    {{- end }}
+    # This value is overridden by using the `ANCHORE_REDIS_URI` environment variable.
+    # redis_ui: $ANCHORE_REDIS_URI
   {{- if .Values.anchoreEnterpriseRbac.enabled }}
     {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
     rbac_uri: 'https://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseRbac.service.apiPort }}/v1'
@@ -47,11 +44,8 @@ data:
     notifications_uri: 'http://{{ template "anchore-engine.api.fullname" . }}:{{ .Values.anchoreEnterpriseNotifications.service.port}}/v1'
     {{- end }}
   {{- end }}
-    {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-    appdb_uri: 'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?ssl=verify-full'
-    {{- else }}
-    appdb_uri: 'postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}'
-    {{- end }}
+    # This value is overridden by using the `ANCHORE_APPDB_URI` environment variable.
+    # appdb_uri: $ANCHORE_APPDB_URI
     license_path: '/home/anchore/'
     enable_ssl: {{ .Values.anchoreEnterpriseUi.enableSsl }}
     enable_proxy: {{ .Values.anchoreEnterpriseUi.enableProxy }}

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -54,6 +54,28 @@ spec:
       {{- end }}
       imagePullSecrets:
       - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
+      initContainers:
+        - name: config-generator
+          image: alpine:latest
+          envFrom:
+          {{- if not .Values.inject_secrets_via_env }}
+          - secretRef:
+              name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+          {{- end }}
+          - configMapRef:
+              name: {{ template "anchore-engine.fullname" . }}-env
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+            - name: anchore-ui-config
+              mountPath: /config/config-ui-vars.yaml
+              subPath: config-ui.yaml
+          command:
+            - sh
+            - -c
+            - (apk add gettext && cat /config/config-ui-vars.yaml | envsubst > /config/config-ui.yaml && chgrp {{ .Values.anchoreGlobal.securityContext.fsGroup }} /config/config-ui.yaml)
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy
@@ -96,9 +118,8 @@ spec:
         - name: anchore-license
           mountPath: /home/anchore/license.yaml
           subPath: license.yaml
-        - name: anchore-ui-config
-          mountPath: /config/config-ui.yaml
-          subPath: config-ui.yaml
+        - name: config-volume
+          mountPath: /config
         {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
         - name: certs
           mountPath: /home/anchore/certs/
@@ -127,8 +148,10 @@ spec:
         secret:
           secretName: {{ .Values.anchoreEnterpriseGlobal.licenseSecretName }}
       - name: anchore-ui-config
-        secret:
-          secretName: {{ template "anchore-engine.enterprise-ui.fullname" . }}
+        configMap:
+          name: {{ template "anchore-engine.enterprise-ui.fullname" . }}
+      - name: config-volume
+        emptyDir: {}
       {{- with .Values.anchoreGlobal.certStoreSecretName }}
       - name: certs
         secret:

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -91,7 +91,7 @@ spec:
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
-            name: {{ default (include "anchore-engine.enterprise-ui.fullname" .) .Values.anchoreGlobal.existingSecret }}
+            name: {{ default (include "anchore-engine.enterprise-ui.fullname" .) .Values.anchoreEnterpriseUi.existingSecret }}
         {{- end }}
         ports:
         - containerPort: 3000

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -74,6 +74,10 @@ spec:
         image: {{ .Values.anchoreEnterpriseUi.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseUi.imagePullPolicy }}
         env:
+        {{- if and (index .Values "anchoreEnterpriseUi" "existingSecret") (not (index .Values "anchore-ui-redis" "externalEndpoint")) }}
+        - name: ANCHORE_REDIS_URI
+          value: redis://:{{ index .Values "anchore-ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379
+        {{- end }}
         {{ if .Values.anchoreGlobal.dbConfig.ssl }}
         - name: PGSSLROOTCERT
           value: /home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }}

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -54,28 +54,6 @@ spec:
       {{- end }}
       imagePullSecrets:
       - name: {{ .Values.anchoreEnterpriseGlobal.imagePullSecretName }}
-      initContainers:
-        - name: config-generator
-          image: alpine:latest
-          envFrom:
-          {{- if not .Values.inject_secrets_via_env }}
-          - secretRef:
-              name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
-          {{- end }}
-          - configMapRef:
-              name: {{ template "anchore-engine.fullname" . }}-env
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: config-volume
-              mountPath: /config
-            - name: anchore-ui-config
-              mountPath: /config/config-ui-vars.yaml
-              subPath: config-ui.yaml
-          command:
-            - sh
-            - -c
-            - (apk add gettext && cat /config/config-ui-vars.yaml | envsubst > /config/config-ui.yaml && chgrp {{ .Values.anchoreGlobal.securityContext.fsGroup }} /config/config-ui.yaml)
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy
@@ -110,6 +88,11 @@ spec:
         {{- with .Values.anchoreEnterpriseUi.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        envFrom:
+        {{- if not .Values.inject_secrets_via_env }}
+        - secretRef:
+            name: {{ default (include "anchore-engine.enterprise-ui.fullname" .) .Values.anchoreGlobal.existingSecret }}
+        {{- end }}
         ports:
         - containerPort: 3000
           protocol: TCP
@@ -118,8 +101,9 @@ spec:
         - name: anchore-license
           mountPath: /home/anchore/license.yaml
           subPath: license.yaml
-        - name: config-volume
-          mountPath: /config
+        - name: anchore-ui-config
+          mountPath: /config/config-ui.yaml
+          subPath: config-ui.yaml
         {{- if (.Values.anchoreGlobal.certStoreSecretName) }}
         - name: certs
           mountPath: /home/anchore/certs/
@@ -150,8 +134,6 @@ spec:
       - name: anchore-ui-config
         configMap:
           name: {{ template "anchore-engine.enterprise-ui.fullname" . }}
-      - name: config-volume
-        emptyDir: {}
       {{- with .Values.anchoreGlobal.certStoreSecretName }}
       - name: certs
         secret:

--- a/stable/anchore-engine/templates/secrets.yaml
+++ b/stable/anchore-engine/templates/secrets.yaml
@@ -18,8 +18,10 @@ stringData:
   {{- with .Values.anchoreGlobal.saml.secret }}
   ANCHORE_SAML_SECRET: {{ . }}
   {{- end }}
+{{- end }}
 
 ---
+{{- if not .Values.anchoreEnterpriseFeeds.existingSecret }}
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
 apiVersion: v1
 kind: Secret
@@ -41,8 +43,10 @@ stringData:
   ANCHORE_SAML_SECRET: {{ . }}
   {{- end }}
 {{- end }}
+{{- end }}
 
 ---
+{{- if not .Values.anchoreEnterpriseUi.existingSecret }}
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseUi.enabled }}
 apiVersion: v1
 kind: Secret

--- a/stable/anchore-engine/templates/secrets.yaml
+++ b/stable/anchore-engine/templates/secrets.yaml
@@ -15,10 +15,61 @@ type: Opaque
 stringData:
   ANCHORE_ADMIN_PASSWORD: {{ include "anchore-engine.defaultAdminPassword" . | quote }}
   ANCHORE_DB_PASSWORD: {{ index .Values "postgresql" "postgresPassword" | quote }}
-  {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
-  ANCHORE_FEEDS_DB_PASSWORD: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}
-  {{- end }}
   {{- with .Values.anchoreGlobal.saml.secret }}
   ANCHORE_SAML_SECRET: {{ . }}
   {{- end }}
+
+---
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+type: Opaque
+stringData:
+  ANCHORE_ADMIN_PASSWORD: {{ include "anchore-engine.defaultAdminPassword" . | quote }}
+  ANCHORE_FEEDS_DB_PASSWORD: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}
+  {{- with .Values.anchoreGlobal.saml.secret }}
+  ANCHORE_SAML_SECRET: {{ . }}
+  {{- end }}
+{{- end }}
+
+---
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseUi.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "anchore-engine.enterprise-ui.fullname" . }}
+  labels:
+    app: {{ template "anchore-engine.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.anchoreGlobal.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+type: Opaque
+stringData:
+  ANCHORE_ADMIN_PASSWORD: {{ include "anchore-engine.defaultAdminPassword" . | quote }}
+
+  {{- if .Values.anchoreGlobal.dbConfig.ssl }}
+  ANCHORE_APPDB_URI: 'postgresql://{{ index .Values "postgresql" "postgresUser" }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}?ssl=verify-full'
+  {{- else }}
+  ANCHORE_APPDB_URI: 'postgresql://{{ index .Values "postgresql" "postgresUser" }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}'
+  {{- end }}
+
+  {{- if and (index .Values "anchore-ui-redis" "externalEndpoint") (not (index .Values "anchore-ui-redis" "enabled")) }}
+  ANCHORE_REDIS_URI: '{{ index .Values "anchore-ui-redis" "externalEndpoint" }}'
+  {{- else }}
+  ANCHORE_REDIS_URI: 'redis://:{{ index .Values "anchore-ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379'
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -104,8 +104,8 @@ anchoreGlobal:
   # Specify a service account name utilized to run all Anchore pods
   serviceAccountName:
 
-  # Set this value to True to setup the chart for OpenShift deployment compatibility.
-  openShiftDeployment: False
+  # Set this value to true to setup the chart for OpenShift deployment compatibility.
+  openShiftDeployment: false
 
   # Add additionnal labels to all kubernetes resources
   labels: {}
@@ -874,7 +874,7 @@ anchoreEnterpriseUi:
     #   value: bar
 
   # Specifies an existing secret to be used for db and redis endpoints
-  # This secret should define the following ENV vars 
+  # This secret should define the following ENV vars
   # ANCHORE_APPDB_URI
   # ANCHORE_REDIS_URI
   existingSecret: Null

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -124,6 +124,10 @@ anchoreGlobal:
     #   value: bar
 
   # Specifies an existing secret to be used for admin and db passwords
+  # The secret should define the following environment vars:
+  # ANCHORE_ADMIN_PASSWORD
+  # ANCHORE_DB_PASSWORD
+  # ANCHORE_SAML_SECRET (if applicable)
   existingSecret: Null
 
   # The scratchVolume controls the mounting of an external volume for scratch space for image analysis. Generally speaking
@@ -698,6 +702,14 @@ anchoreEnterpriseFeeds:
   cycleTimers:
     driver_sync: 7200
 
+  # Specifies an existing secret to be used for anchore admin and db passwords
+  # The secret should define the following environment vars:
+  # ANCHORE_ADMIN_PASSWORD
+  # ANCHORE_FEEDS_DB_PASSWORD
+  # ANCHORE_SAML_SECRET (if applicable)
+
+  existingSecret: Null
+
   # Configure the database connection within anchore-engine & enterprise-ui. This may get split into 2 different configurations based on service utilized.
   dbConfig:
     timeout: 120
@@ -860,6 +872,12 @@ anchoreEnterpriseUi:
   extraEnv: []
     # - name: foo
     #   value: bar
+
+  # Specifies an existing secret to be used for db and redis endpoints
+  # This secret should define the following ENV vars 
+  # ANCHORE_APPDB_URI
+  # ANCHORE_REDIS_URI
+  existingSecret: Null
 
   # If using LDAPS with a custom CA certificate, add the certificate to the secret specified at anchoreGlobal.certStoreSecretName and specify the name of the cert here
   ldapsRootCaCertName: Null


### PR DESCRIPTION
This PR moves env var secrets into service specific k8 secrets (ui, feeds, engine). It also sets up the UI to use ENV vars for all endpoints that contain secrets. This will allow users to specify an existingSecret in their values file for setting secrets outside of their helm deployment.

fixes #91 