### PR TITLE
fix missing logic for mounting an existing secret 

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.11.5
+version: 1.11.6
 appVersion: 0.9.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/api_deployment.yaml
+++ b/stable/anchore-engine/templates/api_deployment.yaml
@@ -317,7 +317,7 @@ spec:
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
-            name: {{ template "anchore-engine.fullname" . }}
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
         {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env
@@ -391,7 +391,7 @@ spec:
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
-            name: {{ template "anchore-engine.fullname" . }}
+            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
         {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.fullname" . }}-env

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -46,7 +46,7 @@ spec:
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}
         - secretRef:
-            name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
+            name: {{ default (include "anchore-engine.enterprise-feeds.fullname" .) .Values.anchoreEnterpriseFeeds.existingSecret }}
         {{- end }}
         - configMapRef:
             name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}-env


### PR DESCRIPTION
the reports, notifications & feeds service deployments were missing logic for mounting existing secrets for env vars.

Signed-off-by: Brady Todhunter <bradyt@anchore.com>