### PR TITLE
Fix typo, update kai version, add comments

### DIFF
--- a/stable/kai/Chart.yaml
+++ b/stable/kai/Chart.yaml
@@ -28,11 +28,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.0
+appVersion: 0.2.0
 
 icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png

--- a/stable/kai/templates/configmap.yaml
+++ b/stable/kai/templates/configmap.yaml
@@ -26,6 +26,7 @@ data:
       url: {{ .Values.kai.anchore.url }}
       user: {{ .Values.kai.anchore.user }}
       password: $KAI_ANCHORE_PASSWORD
+      account: {{ .Values.kai.anchore.account }}
       http:
         insecure: {{ .Values.kai.anchore.http.insecure }}
         timeoutSeconds: {{ .Values.kai.anchore.http.timeoutSeconds }}

--- a/stable/kai/values.yaml
+++ b/stable/kai/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: anchore/kai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.0"
+  tag: "v0.2.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -76,7 +76,7 @@ probes:
     successThreshold: 1
 
 kai:
-  existing_secret: Null
+  existingSecret: Null
 
   # same as -o ; the output format (options: table, json)
   output: "json"
@@ -111,8 +111,10 @@ kai:
 
   anchore:
     url:
+    # Note: the user specified must be an admin user or have full-control, or read-write RBAC permissions
     user: admin
     password: foobar
+    # account: admin # defaults to 'admin' when not specified
     http:
       insecure: true
       timeoutSeconds: 10

--- a/stable/kai/values.yaml
+++ b/stable/kai/values.yaml
@@ -111,10 +111,13 @@ kai:
 
   anchore:
     url:
+
     # Note: the user specified must be an admin user or have full-control, or read-write RBAC permissions
     user: admin
     password: foobar
-    # account: admin # defaults to 'admin' when not specified
+
+    # defaults to 'admin' when not specified
+    account: admin
     http:
       insecure: true
       timeoutSeconds: 10


### PR DESCRIPTION
Changes:
* Update Kai to release 0.2.0 (no functional changes here, just code cleanup)
* Fixes typo in values file for existingSecret (camelcase is used in `deployment.yaml`)
* Adds the anchore account to the configmap (previously only the default value of `admin` was used)
* Add some comments regarding RBAC requirements for the user in the Anchore API configuration section
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>