### PR TITLE
check for nil return value from helm lookup function

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.12.6
+version: 1.12.7
 appVersion: 0.9.3
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/anchore_admin_secret.yaml
+++ b/stable/anchore-engine/templates/anchore_admin_secret.yaml
@@ -10,8 +10,10 @@
 {{- if .Release.IsUpgrade }}
 {{- $adminPassSecret := (lookup "v1" "Secret" .Release.Namespace (print (include "anchore-engine.fullname" .) "-admin-pass")) }}
 {{- $engineSecret := (lookup "v1" "Secret" .Release.Namespace (include "anchore-engine.fullname" . )) -}}
+{{- if or $engineSecret $adminPassSecret }}
 {{- $secret := (default $engineSecret $adminPassSecret) }}
 {{- $anchoreAdminPass = (index $secret.data "ANCHORE_ADMIN_PASSWORD" | b64dec) }}
+{{- end }}
 {{- end }}
 
 apiVersion: v1

--- a/stable/anchore-engine/templates/anchore_admin_secret.yaml
+++ b/stable/anchore-engine/templates/anchore_admin_secret.yaml
@@ -7,7 +7,7 @@
   secret. For users upgrading to chart v1.12.5 or higher, use the new admin-password secret, otherwise use the old
   engine secret.
 */ -}}
-{{- if .Release.IsUpgrade }}
+{{- if and .Release.IsUpgrade (not .Values.anchoreGlobal.defaultAdminPassword) }}
 {{- $adminPassSecret := (lookup "v1" "Secret" .Release.Namespace (print (include "anchore-engine.fullname" .) "-admin-pass")) }}
 {{- $engineSecret := (lookup "v1" "Secret" .Release.Namespace (include "anchore-engine.fullname" . )) -}}
 {{- if or $engineSecret $adminPassSecret }}


### PR DESCRIPTION
fixes #131 

This is not a perfect fix, if the user let helm create a random admin password by not setting `.Values.anchoreGlobal.defaultAdminPassword`, and then performs an upgrade with `--dry-run` the dry run output will show that the ANCHORE_ADMIN_PASSWORD value will change upon upgrade. This will not be the case when the actual upgrade is applied though, helm will lookup & reuse the password found in the existing k8s secret.

Signed-off-by: Brady Todhunter <bradyt@anchore.com>