### PR TITLE
WIP: add gitops method for db automation

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.12.7
+version: 1.12.8
 appVersion: 0.9.3
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
@@ -1,4 +1,5 @@
-{{- if and (not .Values.postgresql.enabled) .Values.anchoreEnterpriseGlobal.enabled }}
+{{- if hasKey .Values.postgresql "enabled" }}
+{{- if (not .Values.postgresql.enabled) }}
 # Job to sync db and db user with external postgres for Anchore's primary data store
 apiVersion: batch/v1
 kind: Job
@@ -15,9 +16,11 @@ spec:
       annotations:
         sidecar.istio.io/inject: 'false'
     spec:
+      imagePullSecrets:
+        - name: {{ .Values.postgresql.imagePullSecrets }}
       containers:
         - name: psql
-          image: "registry1.dso.mil/ironbank/opensource/postgres/postgresql12:12.5"
+          image: {{ .Values.postgresql.image }}
           command:
             - /bin/bash
             - -exc
@@ -30,4 +33,5 @@ spec:
             - secretRef:
                 name: anchore-db-credentials
       restartPolicy: OnFailure
+{{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
@@ -1,0 +1,33 @@
+{{- if and (not .Values.postgresql.enabled) .Values.anchoreEnterpriseGlobal.enabled }}
+# Job to sync db and db user with external postgres for Anchore's primary data store
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ensure-anchore-db
+  annotations:
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: ensure-anchore-db
+      annotations:
+        sidecar.istio.io/inject: 'false'
+    spec:
+      containers:
+        - name: psql
+          image: "registry1.dso.mil/ironbank/opensource/postgres/postgresql12:12.5"
+          command:
+            - /bin/bash
+            - -exc
+            - |   
+              echo "Ensure Anchore DB..."
+              
+              psql -tc "SELECT 1 FROM pg_database WHERE datname = '$ANCHORE_DB'" | grep -q 1 || psql -c "CREATE DATABASE $ANCHORE_DB"
+              psql -tc "SELECT 1 FROM pg_roles WHERE rolname = '$PGUSER'" | grep -q 1 && psql -c "ALTER USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $ANCHORE_DB TO $PGUSER;" | grep -q GRANT || psql -c "CREATE USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $ANCHORE_DB TO $PGUSER;"
+          envFrom:
+            - secretRef:
+                name: anchore-db-credentials
+      restartPolicy: OnFailure
+{{- end }}

--- a/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgresql.createExternalDbAssets }}
 {{- if hasKey .Values.postgresql "enabled" }}
 {{- if (not .Values.postgresql.enabled) }}
 # Job to sync db and db user with external postgres for Anchore's primary data store
@@ -16,8 +17,10 @@ spec:
       annotations:
         sidecar.istio.io/inject: 'false'
     spec:
+      {{- if .Values.postgresql.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.postgresql.imagePullSecrets }}
+      {{- end }}
       containers:
         - name: psql
           image: {{ .Values.postgresql.image }}
@@ -28,10 +31,11 @@ spec:
               echo "Ensure Anchore DB..."
               
               psql -tc "SELECT 1 FROM pg_database WHERE datname = '$ANCHORE_DB'" | grep -q 1 || psql -c "CREATE DATABASE $ANCHORE_DB"
-              psql -tc "SELECT 1 FROM pg_roles WHERE rolname = '$PGUSER'" | grep -q 1 && psql -c "ALTER USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $ANCHORE_DB TO $PGUSER;" | grep -q GRANT || psql -c "CREATE USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $ANCHORE_DB TO $PGUSER;"
+              psql -tc "SELECT 1 FROM pg_roles WHERE rolname = '$APPLICATION_USER'" | grep -q 1 && psql -c "ALTER USER $APPLICATION_USER WITH PASSWORD '$APPLICATION_PASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $ANCHORE_DB TO $APPLICATION_USER;" | grep -q GRANT || psql -c "CREATE USER $APPLICATION_USER WITH PASSWORD '$APPLICATION_PASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $ANCHORE_DB TO $APPLICATION_USER;"
           envFrom:
             - secretRef:
                 name: anchore-db-credentials
       restartPolicy: OnFailure
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/anchore_db_ensure_job.yaml
@@ -17,9 +17,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: 'false'
     spec:
-      {{- if .Values.postgresql.imagePullSecrets }}
+      {{- if .Values.postgresql.imagePullSecretName }}
       imagePullSecrets:
-        - name: {{ .Values.postgresql.imagePullSecrets }}
+        - name: {{ .Values.postgresql.imagePullSecretName }}
       {{- end }}
       containers:
         - name: psql

--- a/stable/anchore-engine/templates/anchore_db_secret.yaml
+++ b/stable/anchore-engine/templates/anchore_db_secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgresql.createExternalDbAssets }}
 {{- if hasKey .Values.postgresql "enabled" }}
 {{- if (not .Values.postgresql.enabled) }}
 apiVersion: v1
@@ -23,5 +24,8 @@ data:
   PGHOST: {{$v := .Values.postgresql.externalEndpoint | split ":"}}{{b64enc $v._0}}
   PGPORT: "{{$v := .Values.postgresql.externalEndpoint | split ":"}}{{b64enc $v._1}}"
   ANCHORE_DB: {{ b64enc .Values.postgresql.postgresDatabase }}
+  APPLICATION_USER: {{ b64enc .Values.postgresql.applicationUser }}
+  APPLICATION_PASSWORD: {{ b64enc .Values.postgresql.applicationPassword }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/anchore_db_secret.yaml
+++ b/stable/anchore-engine/templates/anchore_db_secret.yaml
@@ -1,4 +1,5 @@
-{{- if and (not .Values.postgresql.enabled) .Values.anchoreEnterpriseGlobal.enabled }}
+{{- if hasKey .Values.postgresql "enabled" }}
+{{- if (not .Values.postgresql.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,4 +23,5 @@ data:
   PGHOST: {{$v := .Values.postgresql.externalEndpoint | split ":"}}{{b64enc $v._0}}
   PGPORT: "{{$v := .Values.postgresql.externalEndpoint | split ":"}}{{b64enc $v._1}}"
   ANCHORE_DB: {{ b64enc .Values.postgresql.postgresDatabase }}
+{{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/anchore_db_secret.yaml
+++ b/stable/anchore-engine/templates/anchore_db_secret.yaml
@@ -1,0 +1,25 @@
+{{- if and (not .Values.postgresql.enabled) .Values.anchoreEnterpriseGlobal.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anchore-db-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: anchore-db-secret
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: anchore-enterprise
+    app.kubernetes.io/component: database
+  annotations:
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+type: Opaque
+data:
+  PGUSER: {{ b64enc .Values.postgresql.postgresUser }}
+  PGPASSWORD: {{ b64enc .Values.postgresql.postgresPassword }}
+  PGDATABASE: {{ b64enc "postgres" }}
+  PGHOST: {{$v := .Values.postgresql.externalEndpoint | split ":"}}{{b64enc $v._0}}
+  PGPORT: "{{$v := .Values.postgresql.externalEndpoint | split ":"}}{{b64enc $v._1}}"
+  ANCHORE_DB: {{ b64enc .Values.postgresql.postgresDatabase }}
+{{- end }}

--- a/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
@@ -1,0 +1,33 @@
+{{- if and (not (index .Values "anchore-feeds-db" "enabled")) .Values.anchoreEnterpriseGlobal.enabled }}
+# Job to sync db and db user with external postgres for Anchore's feeds db
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ensure-feeds-db
+  annotations:
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: ensure-feeds-db
+      annotations:
+        sidecar.istio.io/inject: 'false'
+    spec:
+      containers:
+        - name: psql
+          image: "registry1.dso.mil/ironbank/opensource/postgres/postgresql12:12.5"
+          command:
+            - /bin/bash
+            - -exc
+            - |   
+              echo "Ensure Anchore Feeds DB..."
+              
+              psql -tc "SELECT 1 FROM pg_database WHERE datname = '$FEEDS_DB'" | grep -q 1 || psql -c "CREATE DATABASE $FEEDS_DB"
+              psql -tc "SELECT 1 FROM pg_roles WHERE rolname = '$PGUSER'" | grep -q 1 && psql -c "ALTER USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $FEEDS_DB TO $PGUSER;" | grep -q GRANT || psql -c "CREATE USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $FEEDS_DB TO $PGUSER;"
+          envFrom:
+            - secretRef:
+                name: feeds-db-credentials
+      restartPolicy: OnFailure
+{{- end }}

--- a/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values "anchore-feeds-db" "createExternalDbAssets") }}
 {{- if and (hasKey (index .Values "anchore-feeds-db") "enabled")  }}
 {{- if and (not (index .Values "anchore-feeds-db" "enabled")) .Values.anchoreEnterpriseGlobal.enabled }}
 # Job to sync db and db user with external postgres for Anchore's feeds db
@@ -16,8 +17,10 @@ spec:
       annotations:
         sidecar.istio.io/inject: 'false'
     spec:
+      {{- if (index .Values "anchore-feeds-db" "imagePullSecrets") }}
       imagePullSecrets:
         - name: {{ (index .Values "anchore-feeds-db" "imagePullSecrets") }}
+      {{- end }}
       containers:
         - name: psql
           image: {{ (index .Values "anchore-feeds-db" "image") }}
@@ -28,10 +31,11 @@ spec:
               echo "Ensure Anchore Feeds DB..."
               
               psql -tc "SELECT 1 FROM pg_database WHERE datname = '$FEEDS_DB'" | grep -q 1 || psql -c "CREATE DATABASE $FEEDS_DB"
-              psql -tc "SELECT 1 FROM pg_roles WHERE rolname = '$PGUSER'" | grep -q 1 && psql -c "ALTER USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $FEEDS_DB TO $PGUSER;" | grep -q GRANT || psql -c "CREATE USER $PGUSER WITH PASSWORD '$PGPASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $FEEDS_DB TO $PGUSER;"
+              psql -tc "SELECT 1 FROM pg_roles WHERE rolname = '$APPLICATION_USER'" | grep -q 1 && psql -c "ALTER USER $APPLICATION_USER WITH PASSWORD '$APPLICATION_PASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $FEEDS_DB TO $APPLICATION_USER;" | grep -q GRANT || psql -c "CREATE USER $APPLICATION_USER WITH PASSWORD '$APPLICATION_PASSWORD'; GRANT ALL PRIVILEGES ON DATABASE $FEEDS_DB TO $APPLICATION_USER;"
           envFrom:
             - secretRef:
                 name: feeds-db-credentials
       restartPolicy: OnFailure
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
@@ -17,9 +17,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: 'false'
     spec:
-      {{- if (index .Values "anchore-feeds-db" "imagePullSecrets") }}
+      {{- if (index .Values "anchore-feeds-db" "imagePullSecretName") }}
       imagePullSecrets:
-        - name: {{ (index .Values "anchore-feeds-db" "imagePullSecrets") }}
+        - name: {{ (index .Values "anchore-feeds-db" "imagePullSecretName") }}
       {{- end }}
       containers:
         - name: psql

--- a/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
+++ b/stable/anchore-engine/templates/feeds_db_ensure_job.yaml
@@ -1,3 +1,4 @@
+{{- if and (hasKey (index .Values "anchore-feeds-db") "enabled")  }}
 {{- if and (not (index .Values "anchore-feeds-db" "enabled")) .Values.anchoreEnterpriseGlobal.enabled }}
 # Job to sync db and db user with external postgres for Anchore's feeds db
 apiVersion: batch/v1
@@ -15,9 +16,11 @@ spec:
       annotations:
         sidecar.istio.io/inject: 'false'
     spec:
+      imagePullSecrets:
+        - name: {{ (index .Values "anchore-feeds-db" "imagePullSecrets") }}
       containers:
         - name: psql
-          image: "registry1.dso.mil/ironbank/opensource/postgres/postgresql12:12.5"
+          image: {{ (index .Values "anchore-feeds-db" "image") }}
           command:
             - /bin/bash
             - -exc
@@ -30,4 +33,5 @@ spec:
             - secretRef:
                 name: feeds-db-credentials
       restartPolicy: OnFailure
+{{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/feeds_db_secret.yaml
+++ b/stable/anchore-engine/templates/feeds_db_secret.yaml
@@ -1,3 +1,4 @@
+{{- if and (hasKey (index .Values "anchore-feeds-db") "enabled")  }}
 {{- if and (not (index .Values "anchore-feeds-db" "enabled")) .Values.anchoreEnterpriseGlobal.enabled }}
 apiVersion: v1
 kind: Secret
@@ -22,4 +23,5 @@ data:
   PGHOST: {{$v := (index .Values "anchore-feeds-db" "externalEndpoint") | split ":"}}{{b64enc $v._0}}
   PGPORT: "{{$v := (index .Values "anchore-feeds-db" "externalEndpoint") | split ":"}}{{b64enc $v._1}}"
   FEEDS_DB: {{ b64enc (index .Values "anchore-feeds-db" "postgresDatabase") }}
+{{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/feeds_db_secret.yaml
+++ b/stable/anchore-engine/templates/feeds_db_secret.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values "anchore-feeds-db" "createExternalDbAssets") }}
 {{- if and (hasKey (index .Values "anchore-feeds-db") "enabled")  }}
 {{- if and (not (index .Values "anchore-feeds-db" "enabled")) .Values.anchoreEnterpriseGlobal.enabled }}
 apiVersion: v1
@@ -23,5 +24,8 @@ data:
   PGHOST: {{$v := (index .Values "anchore-feeds-db" "externalEndpoint") | split ":"}}{{b64enc $v._0}}
   PGPORT: "{{$v := (index .Values "anchore-feeds-db" "externalEndpoint") | split ":"}}{{b64enc $v._1}}"
   FEEDS_DB: {{ b64enc (index .Values "anchore-feeds-db" "postgresDatabase") }}
+  APPLICATION_USER: {{ b64enc (index .Values "anchore-feeds-db" "applicationUser") }}
+  APPLICATION_PASSWORD: {{ b64enc (index .Values "anchore-feeds-db" "applicationPassword") }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/feeds_db_secret.yaml
+++ b/stable/anchore-engine/templates/feeds_db_secret.yaml
@@ -1,0 +1,25 @@
+{{- if and (not (index .Values "anchore-feeds-db" "enabled")) .Values.anchoreEnterpriseGlobal.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: feeds-db-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: feeds-db-secret
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: anchore-enterprise
+    app.kubernetes.io/component: database
+  annotations:
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+type: Opaque
+data:
+  PGUSER: {{ b64enc (index .Values "anchore-feeds-db" "postgresUser") }}
+  PGPASSWORD: {{ b64enc (index .Values "anchore-feeds-db" "postgresPassword") }}
+  PGDATABASE: {{ b64enc "postgres" }}
+  PGHOST: {{$v := (index .Values "anchore-feeds-db" "externalEndpoint") | split ":"}}{{b64enc $v._0}}
+  PGPORT: "{{$v := (index .Values "anchore-feeds-db" "externalEndpoint") | split ":"}}{{b64enc $v._1}}"
+  FEEDS_DB: {{ b64enc (index .Values "anchore-feeds-db" "postgresDatabase") }}
+{{- end }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -2,9 +2,9 @@
 
 # Anchore engine has a dependency on Postgresql, configure here
 postgresql:
-  # To use an external DB or Google CloudSQL in GKE, set 'enabled: false'
+  # To use an external DB or Google CloudSQL in GKE, uncomment & set 'enabled: false'
   # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
-  enabled: true
+  # enabled: false
   postgresUser: anchoreengine
   postgresPassword: anchore-postgres,123
   postgresDatabase: anchore
@@ -647,9 +647,9 @@ anchoreEnterpriseGlobal:
 # Configure the second postgres database instance for the enterprise feeds service.
 # Only utilized if anchoreEnterpriseGlobal.enabled: true
 anchore-feeds-db:
-  # To use an external DB or Google CloudSQL, set 'enabled: false'
+  # To use an external DB or Google CloudSQL, uncomment & set 'enabled: false'
   # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
-  enabled: true
+  # enabled: false
   postgresUser: anchoreengine
   postgresPassword: anchore-postgres,123
   postgresDatabase: anchore-feeds

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -2,6 +2,13 @@
 
 # Anchore engine has a dependency on Postgresql, configure here
 postgresql:
+  # Image used for all postgres jobs
+  image: docker.io/postgres:9.6.18
+  imagePullPolicy: IfNotPresent
+
+  # Set image pull secret name if using a postgres image from a private registry
+  imagePullSecretName: ""
+
   # To use an external DB or Google CloudSQL in GKE, uncomment & set 'enabled: false'
   # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
   # enabled: false
@@ -12,6 +19,12 @@ postgresql:
   # Specify an external (already existing) postgres deployment for use.
   # Set to the host and port. eg. mypostgres.myserver.io:5432
   externalEndpoint: Null
+
+  # To automatically create external DB and application user, set 'createExternalDbAssets: true'
+  # applicationUser and applicationPassword are required values for creating external DB assets (can be the same as postgresUser/postgresPassword but not recommended)
+  createExternalDbAssets: false
+  applicationUser: anchoreengine-user
+  applicationPassword: anchore-postgres-user,123
 
   # Configure size of the persistent volume used with helm managed chart.
   # This should be commented out if using an external endpoint.
@@ -647,6 +660,13 @@ anchoreEnterpriseGlobal:
 # Configure the second postgres database instance for the enterprise feeds service.
 # Only utilized if anchoreEnterpriseGlobal.enabled: true
 anchore-feeds-db:
+  # Image used for all postgres jobs
+  image: docker.io/postgres:9.6.18
+  imagePullPolicy: IfNotPresent
+
+  # Set image pull secret name if using a postgres image from a private registry
+  imagePullSecretName: ""
+
   # To use an external DB or Google CloudSQL, uncomment & set 'enabled: false'
   # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
   # enabled: false
@@ -658,6 +678,12 @@ anchore-feeds-db:
   # Set to the host and port. eg. mypostgres.myserver.io:5432
   externalEndpoint: Null
 
+  # To automatically create external DB and application user, set 'createExternalDbAssets: true'
+  # applicationUser and applicationPassword are required values for creating external DB assets (can be the same as postgresUser/postgresPassword but not recommended)
+  createExternalDbAssets: false
+  applicationUser: anchoreengine-user
+  applicationPassword: anchore-postgres-user,123
+  
   # Configure size of the persitant volume used with helm managed chart.
   # This should be commented out if using an external endpoint.
   persistence:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -2,9 +2,9 @@
 
 # Anchore engine has a dependency on Postgresql, configure here
 postgresql:
-  # To use an external DB or Google CloudSQL in GKE, uncomment & set 'enabled: false'
+  # To use an external DB or Google CloudSQL in GKE, set 'enabled: false'
   # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
-  # enabled: false
+  enabled: true
   postgresUser: anchoreengine
   postgresPassword: anchore-postgres,123
   postgresDatabase: anchore
@@ -647,9 +647,9 @@ anchoreEnterpriseGlobal:
 # Configure the second postgres database instance for the enterprise feeds service.
 # Only utilized if anchoreEnterpriseGlobal.enabled: true
 anchore-feeds-db:
-  # To use an external DB or Google CloudSQL, uncomment & set 'enabled: false'
+  # To use an external DB or Google CloudSQL, set 'enabled: false'
   # externalEndpoint, postgresUser, postgresPassword & postgresDatabase are required values for external postgres
-  # enabled: false
+  enabled: true
   postgresUser: anchoreengine
   postgresPassword: anchore-postgres,123
   postgresDatabase: anchore-feeds


### PR DESCRIPTION
This PR aims to solve a potential use case for gitops teams who are using external postgres databases. Two new jobs were introduced to utilize postgres credentials (from values.yaml) from two new secrets in order to automate the following:
- selecting OR creating a database
- selecting a database user and altering that user to have database privileges OR creating a database user and altering that user to have database privileges

################

**Notes:**
- `pre-install,pre-upgrade` Helm hooks were used instead of `post-install,post-upgrade` so that the anchore jobs/components wouldn't error on "$DATABASE does not exist"
- Weights were used so the secrets (-5) would be created before the jobs (-4)
- Separate secrets and jobs were used for the main-db and feeds-db so users could use different database endpoints and credentials in values.yaml

**Concerns:**
- the jobs use a postgresql image that would need to be specified in values.yaml
- the jobs use imagePullSecrets that would need to be specified in values.yaml

**Known Issues:**
- if users set their database names with a hyphen (ie. anchore-feeds) the psql commands in the jobs will fail
- when upgrading in certain scenarios (ie. engine to enterprise, internal postgres to external dbs,) the engine-upgrade job will fail and restart 3-4 times until the anchore pods are ready, then the job will complete and the helm release will be ready

Signed-off-by: bhearn7 <blakeeh723@gmail.com>