### PR TITLE
Don't use unset ENV vars in config file

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.12.11
+version: 1.12.12
 appVersion: 0.9.3
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -70,8 +70,6 @@ data:
           vulndb: false
           microsoft: false
           {{- end }}
-          # Sync github data if available for GHSA matches
-          github: {{ default "true" .Values.anchoreGlobal.syncGithub }}
     {{- if .Values.anchoreEnterpriseFeeds.url }}
       url: "{{- .Values.anchoreEnterpriseFeeds.url }}"
       ssl_verify: {{ .Values.anchoreGlobal.internalServicesSsl.verifyCerts }}

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -45,7 +45,9 @@ data:
         # If enabled only sync specific feeds instead of all that are found.
         enabled: true
         feeds:
-          {{- if not .Values.anchoreEnterpriseGlobal.enabled }}
+          {{- if .Values.anchoreEnterpriseGlobal.enabled }}
+          github: {{ .Values.anchoreEnterpriseFeeds.githubDriverEnabled }}
+          {{- else }}
           github: {{ default "true" .Values.anchoreGlobal.syncGithub }}
           {{- end }}
           # Vulnerabilities feed is the feed for distro cve sources (redhat, debian, ubuntu, oracle, alpine....)

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -126,16 +126,20 @@ data:
             enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.nvdv2DriverEnabled }}
           vulndb:
             enabled: {{ default "true" .Values.anchoreEnterpriseFeeds.vulndbDriverEnabled }}
+        {{- if .Values.anchoreEnterpriseFeeds.msrcDriverEnabled }}
           msrc:
-            enabled: {{ .Values.anchoreEnterpriseFeeds.msrcDriverEnabled }}
+            enabled: true
             api_key: ${ANCHORE_MSRC_KEY}
             {{- with .Values.anchoreEnterpriseFeeds.msrcWhitelist }}
             whitelist:
               - {{ . }}
             {{- end }}
+        {{- end }}
+        {{- if .Values.anchoreEnterpriseFeeds.githubDriverEnabled }}
           github:
-            enabled: {{ .Values.anchoreEnterpriseFeeds.githubDriverEnabled }}
+            enabled: true
             token: ${ANCHORE_GITHUB_TOKEN}
+        {{- end }}
         {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
         ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
         ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"


### PR DESCRIPTION
Ensure that the github & msrc feed configurations are set conditionally based on being enabled in the values file.

Signed-off-by: Brady Todhunter <bradyt@anchore.com>