### PR TITLE
Add OOB inventory details

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.12.15
+version: 1.12.16
 appVersion: 0.9.4
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -231,7 +231,13 @@ data:
         ssl_key: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretKeyName }}"
         {{- end }}
         runtime_inventory:
-          image_ttl_days: {{ .Values.anchoreCatalog.runtime_inventory.image_ttl_days }}
+          image_ttl_days: {{ .Values.anchoreCatalog.runtimeInventory.imageTTLDays }}
+          kubernetes:
+            report_anchore_cluster:
+              enabled: {{ .Values.anchoreCatalog.runtimeInventory.reportAnchoreCluster.enabled }}
+              anchore_cluster_name: {{ .Values.anchoreCatalog.runtimeInventory.reportAnchoreCluster.clusterName }}
+              namespaces:
+                {{- toYaml .Values.anchoreCatalog.runtimeInventory.reportAnchoreCluster.namespaces | nindent 16 }}
       simplequeue:
         enabled: true
         require_auth: true

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -549,12 +549,21 @@ anchoreCatalog:
   tolerations: []
   affinity: {}
 
-  runtime_inventory:
+  runtimeInventory:
     # This setting tells Anchore how long an image can be missing from an inventory report before it is removed from
     # The working set. Note: The image will still have a historical record in the reports service, subject to data history
     # constraints as part of that service.
     # Note: if a runtime inventory image's digest is also in anchore for regular image analysis, it won't be removed.
-    image_ttl_days: 1
+    imageTTLDays: 1
+
+    # Since Anchore is running in Kubernetes, we can collect runtime inventory data out of the box
+    reportAnchoreCluster:
+      # If set to true, Anchore will use its own service-account to try and collect runtime inventory data for all namespaces
+      # Note: requires a value for clusterName to populate inventory image context
+      enabled: true
+      clusterName: anchore-k8s
+      namespaces:
+        - all
 
 # Pod configuration for the anchore engine policy service.
 anchorePolicyEngine:


### PR DESCRIPTION
Add OOB runtime inventory configuration details to the helm chart.
This will allow anchore, running in the helm chart, to be able to collect inventory information from the cluster that it's in, out of the box (without user intervention required, by default)


Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>