### PR TITLE
Add option to use Cloud SQL IAM authentication

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.14.2
-appVersion: 0.10.1
+version: 1.20.2
+appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:
  - analysis

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.14.1
+version: 1.14.2
 appVersion: 0.10.1
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/analyzer_deployment.yaml
+++ b/stable/anchore-engine/templates/analyzer_deployment.yaml
@@ -84,6 +84,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/api_deployment.yaml
+++ b/stable/anchore-engine/templates/api_deployment.yaml
@@ -72,6 +72,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/catalog_deployment.yaml
+++ b/stable/anchore-engine/templates/catalog_deployment.yaml
@@ -72,6 +72,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -52,6 +52,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -77,6 +77,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -45,6 +45,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -66,6 +66,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -45,6 +45,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/policy_engine_deployment.yaml
+++ b/stable/anchore-engine/templates/policy_engine_deployment.yaml
@@ -83,6 +83,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/templates/simplequeue_deployment.yaml
+++ b/stable/anchore-engine/templates/simplequeue_deployment.yaml
@@ -69,6 +69,9 @@ spec:
         command: ["/cloud_sql_proxy"]
         args:
         - "-instances={{ .Values.cloudsql.instance }}=tcp:5432"
+        {{- if .Values.cloudsql.enableIamLogin }}
+        - "-enable_iam_login"
+        {{- end }}
         {{- if .Values.cloudsql.useExistingServiceAcc }}
         - "-credential_file=/var/{{ .Values.cloudsql.serviceAccSecretName }}/{{ .Values.cloudsql.serviceAccJsonName }}"
         volumeMounts:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -42,6 +42,8 @@ cloudsql:
   enabled: false
   # set CloudSQL instance: 'project:zone:instancname'
   instance: ""
+  # Enables the proxy to use Cloud SQL IAM authentication
+  # enableIamLogin: false
   # Optional existing service account secret to use.
   # useExistingServiceAcc: false
   # serviceAccSecretName: service_acc


### PR DESCRIPTION
CloudSQL supports IAM database authentication which allows a passwordless access to database instance using service account key. To use this feature with cloud_sql_proxy, we need to pass `-enable_iam_login` parameter.

References:
* https://cloud.google.com/sql/docs/postgres/authentication?hl=en-us
* https://github.com/GoogleCloudPlatform/cloudsql-proxy#-enable_iam_login