### PR TITLE
Fix connection strings for db using TLS

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.14.3
+version: 1.14.4
 appVersion: 0.10.1
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -561,7 +561,9 @@ anchoreEnterpriseUI:
 
 ## Install using an existing/external PostgreSQL instance
 
-*Note: it is recommended to use an external Postgresql instance for production installs*
+*Note: it is recommended to use an external Postgresql instance for production installs.*
+
+See comments in the values.yaml file for details on using SSL for external database connections.
 
 ```yaml
 postgresql:
@@ -574,6 +576,7 @@ postgresql:
 anchoreGlobal:
   dbConfig:
     ssl: true
+    sslMode: require
 ```
 
 ## Install using Google CloudSQL

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -82,10 +82,12 @@ data:
 
     credentials:
       database:
-        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName -}}"
-        {{- else }}
+        {{- if not .Values.anchoreGlobal.dbConfig.ssl }}
         db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
+        {{- else if eq .Values.anchoreGlobal.dbConfig.sslMode "require" }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}"
+        {{- else }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName -}}"
         {{- end }}
         db_connect_args:
           timeout: {{ .Values.anchoreGlobal.dbConfig.timeout }}

--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -70,12 +70,15 @@ spec:
         {{- end }}
         command: ["/bin/bash", "-c"]
         args:
-        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-          - |
-            anchore-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
-        {{- else }}
+        {{- if not .Values.anchoreGlobal.dbConfig.ssl }}
           - |
             anchore-manager db --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}" upgrade --dontask;
+        {{- else if eq .Values.anchoreGlobal.dbConfig.sslMode "require"}}
+          - |
+            anchore-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode }} upgrade --dontask;
+        {{- else }}
+          - |
+            anchore-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
         {{- end }}
         {{- if .Values.cloudsql.enabled }}
             sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;

--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -72,10 +72,10 @@ spec:
         args:
         {{- if .Values.anchoreGlobal.dbConfig.ssl }}
           - |
-            anchore-manager db --db-use-ssl --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{ .Values.anchoreGlobal.dbConfig.sslMode }}\\&sslrootcert=/home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
+            anchore-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
         {{- else }}
           - |
-            anchore-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask;
+            anchore-manager db --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}" upgrade --dontask;
         {{- end }}
         {{- if .Values.cloudsql.enabled }}
             sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -64,10 +64,12 @@ data:
 
     credentials:
       database:
-        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }}"
-        {{- else }}
+        {{- if not .Values.anchoreGlobal.dbConfig.ssl }}
         db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
+        {{- else if eq .Values.anchoreGlobal.dbConfig.sslMode "require" }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}"
+        {{- else }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName -}}"
         {{- end }}
         db_connect_args:
           timeout: {{ .Values.anchoreGlobal.dbConfig.timeout }}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -58,10 +58,12 @@ data:
 
     credentials:
       database:
-        {{- if .Values.anchoreEnterpriseFeeds.dbConfig.ssl }}
-        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreEnterpriseFeeds.dbConfig.sslRootCertName }}"
-        {{- else }}
+        {{- if not .Values.anchoreEnterpriseFeeds.dbConfig.ssl }}
         db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}"
+        {{- else if eq .Values.anchoreEnterpriseFeeds.dbConfig.sslMode "require" }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode -}}"
+        {{- else }}
+        db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode -}}&sslrootcert=/home/anchore/certs/{{- .Values.anchoreEnterpriseFeeds.dbConfig.sslRootCertName }}"
         {{- end }}
         db_connect_args:
           timeout: {{ .Values.anchoreEnterpriseFeeds.dbConfig.timeout }}

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -60,10 +60,10 @@ spec:
         args:
         {{- if .Values.anchoreGlobal.dbConfig.ssl }}
           - |
-            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{ .Values.anchoreGlobal.dbConfig.sslMode }}\\&sslrootcert=/home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
+            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_FEEDS_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
         {{- else }}
           - |
-            anchore-enterprise-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_FEEDS_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask;
+            anchore-enterprise-manager db --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_FEEDS_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}" upgrade --dontask;
         {{- end }}
         {{- if .Values.cloudsql.enabled }}
             sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -58,12 +58,15 @@ spec:
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         command: ["/bin/bash", "-c"]
         args:
-        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-          - |
-            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_FEEDS_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
-        {{- else }}
+        {{- if not .Values.anchoreEnterpriseFeeds.dbConfig.ssl }}
           - |
             anchore-enterprise-manager db --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_FEEDS_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}" upgrade --dontask;
+        {{- else if eq .Values.anchoreEnterpriseFeeds.dbConfig.sslMode "require" }}
+          - |
+            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_FEEDS_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode }} upgrade --dontask;
+        {{- else }}
+          - |
+            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_FEEDS_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreEnterpriseFeeds.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreEnterpriseFeeds.dbConfig.sslRootCertName }} upgrade --dontask;
         {{- end }}
         {{- if .Values.cloudsql.enabled }}
             sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -60,10 +60,10 @@ spec:
         args:
         {{- if .Values.anchoreGlobal.dbConfig.ssl }}
           - |
-            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME}?sslmode={{ .Values.anchoreGlobal.dbConfig.sslMode }}\\&sslrootcert=/home/anchore/certs/{{ .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
+            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
         {{- else }}
           - |
-            anchore-enterprise-manager db --db-connect postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}/${ANCHORE_DB_NAME} upgrade --dontask;
+            anchore-enterprise-manager db --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}" upgrade --dontask;
         {{- end }}
         {{- if .Values.cloudsql.enabled }}
             sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -58,12 +58,15 @@ spec:
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         command: ["/bin/bash", "-c"]
         args:
-        {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-          - |
-            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
-        {{- else }}
+        {{- if not .Values.anchoreGlobal.dbConfig.ssl }}
           - |
             anchore-enterprise-manager db --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}" upgrade --dontask;
+        {{- else if eq .Values.anchoreGlobal.dbConfig.sslMode "require" }}
+          - |
+            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode }} upgrade --dontask;
+        {{- else }}
+          - |
+            anchore-enterprise-manager db --db-use-ssl --db-connect postgresql://"${ANCHORE_DB_USER}":"${ANCHORE_DB_PASSWORD}"@"${ANCHORE_DB_HOST}"/"${ANCHORE_DB_NAME}"?sslmode={{- .Values.anchoreGlobal.dbConfig.sslMode -}}\&sslrootcert=/home/anchore/certs/{{- .Values.anchoreGlobal.dbConfig.sslRootCertName }} upgrade --dontask;
         {{- end }}
         {{- if .Values.cloudsql.enabled }}
             sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -200,11 +200,12 @@ anchoreGlobal:
   # Configure the database connection within anchore-engine & enterprise-ui. This may get split into 2 different configurations based on service utilized.
   dbConfig:
     timeout: 120
-    # Use ssl, but the default postgresql config in helm's stable repo does not support ssl on server side, so this should be set for external dbs only.
-    # All ssl dbConfig values are only utilized when ssl=true
+    # Use ssl, but the default postgresql config from the dependent chart does not support server side ssl, so this should only be enabled for external dbs
     ssl: false
+    # set sslMode to `require` to ignore verifying the root CA - see https://www.postgresql.org/docs/9.1/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
     sslMode: verify-full
-    # sslRootCertName is the name of the postgres root CA certificate stored in anchoreGlobal.certStoreSecretName
+    # Specify path to an additional root CA certificate - this is only utilized if 'ssl: true & sslMode: verify-full' are configured.
+    # sslRootCertName describes the filename that is mounted in `/home/anchore/certs` from the secret defined in anchoreGlobal.certStoreSecretName
     sslRootCertName: Null
     connectionPoolSize: 30
     connectionPoolMaxOverflow: 100
@@ -767,10 +768,12 @@ anchoreEnterpriseFeeds:
   # Configure the database connection within anchore-engine & enterprise-ui. This may get split into 2 different configurations based on service utilized.
   dbConfig:
     timeout: 120
-    # Use ssl, but the default postgresql config in helm's stable repo does not support ssl on server side, so this should be set for external dbs
+    # Use ssl, but the default postgresql config from the dependent chart does not support server side ssl, so this should only be enabled for external dbs
     ssl: false
+    # set sslMode to `require` to ignore verifying the root CA - see https://www.postgresql.org/docs/9.1/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
     sslMode: verify-full
-    # Specify path to an additional root CA certificate - this is only utilized if 'ssl: true' is configured.
+    # Specify path to an additional root CA certificate - this is only utilized if 'ssl: true & sslMode: verify-full' are configured.
+    # sslRootCertName describes the filename that is mounted in `/home/anchore/certs` from the secret defined in anchoreGlobal.certStoreSecretName
     sslRootCertName: Null
     connectionPoolSize: 30
     connectionPoolMaxOverflow: 100


### PR DESCRIPTION
Fixed an issue with the DB upgrade job, when using TLS, that didn't allow specifying the root cert path due to not handling white space & escape characters properly.

Fixed sslMode=require getting forced to verify-all because the cert path was always specified in the connection string. See https://www.postgresql.org/docs/9.1/libpq-ssl.html