### PR TITLE
update feeds metrics settings

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.14.2
+version: 1.14.3
 appVersion: 0.10.1
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -30,6 +30,7 @@ data:
     license_file: /home/anchore/license.yaml
     metrics:
       enabled: {{ .Values.anchoreGlobal.enableMetrics }}
+      auth_disabled: {{ .Values.anchoreGlobal.metricsAuthDisabled }}
 
     # Locations for keys used for signing and encryption. Only one of 'secret' or 'public_key_path'/'private_key_path' needs to be set. If all are set then the keys take precedence over the secret value
     # Secret is for a shared secret and if set, all components in anchore should have the exact same value in their configs.


### PR DESCRIPTION
When installing/upgrading anchore with the following values, I am blocked from accessing the enterprise feeds metrics even though `.Values.metricsAuthDisabled` is true:
```yaml
anchoreGlobal:
  enableMetrics: true
  metricsAuthDisabled: true

anchoreEnterpriseGlobal:
  enabled: true
```
```shell
k -n anchore exec -it anchore-anchore-engine-enterprise-feeds-6f75c9557-8jv98 -- curl localhost:8448/metrics
Unauthorized
```

This PR aims to solve this problem by adding the option to the feeds configmap (like the other configmaps have). Once the feeds configmap has been updated, I am able to get metrics
```shell
k -n anchore exec -it anchore-anchore-engine-enterprise-feeds-bf4c4954f-6ctkg -- curl localhost:8448/metrics
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 121421.0
...
anchore_service_info{servicename="feeds",version="0.10.1"} 1.0
```

Signed-off-by: bhearn7 <blakeeh723@gmail.com>