### PR TITLE
feat: add ingress className

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.14.5
+version: 1.14.6
 appVersion: 0.10.2
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/ingress.yaml
+++ b/stable/anchore-engine/templates/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
     {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -71,6 +71,10 @@ ingress:
   # uncomment `feedsPath` to add an ingress endpoint for the feeds api
   # uncomment 'reportsPath' to add an ingress endpoint for the reports api
 
+  # Set ingressClassName if kubernetes version is >= 1.18
+  # Reference: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  # ingressClassName: nginx
+
   # Uncomment the following lines to bind on specific hostnames
   # apiHosts:
   #   - anchore-api.example.com


### PR DESCRIPTION
Adding new optional parameter `ingressClassName` to the `anchore` chart.

For more information on `ingressClassName` see [here](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/)