### PR TITLE
Adds configuration support for grype db feeds

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.14.6
+version: 1.14.7
 appVersion: 0.10.2
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -1,26 +1,20 @@
-{{ $anchoreFeedsURL := "https://ancho.re/v1/service/feeds" }}
-{{- if .Values.anchoreEnterpriseFeeds.url }}
-{{- $anchoreFeedsURL = .Values.anchoreEnterpriseFeeds.url }}
-{{- else if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
-{{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
-{{- $anchoreFeedsURL = (printf "https://%s:%s/v1/feeds"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
-{{- else }}
-{{- $anchoreFeedsURL = (printf "http://%s:%s/v1/feeds" (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
-{{- end }}
-{{- end }}
+{{- $anchoreFeedsURL := "https://ancho.re/v1/service/feeds" -}}
+{{- $grypeProviderFeedsExternalURL := "https://toolbox-data.anchore.io/grype/databases/listing.json" -}}
 
-{{ $grypeProviderFeedsExternalURL := "" }}
-{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
-{{- if .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL }}
-{{- $grypeProviderFeedsExternalURL = (printf "%s/databases/grype" .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL) }}
-{{- else if .Values.anchoreGlobal.internalServicesSsl.enabled }}
-{{- $grypeProviderFeedsExternalURL = (printf "https://%s:%s/v1/databases/grype"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
-{{- else }}
-{{- $grypeProviderFeedsExternalURL = (printf "http://%s:%s/v1/databases/grype"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
-{{- end }}
-{{ - else }}
-{{- $grypeProviderFeedsExternalURL = "https://toolbox-data.anchore.io/grype/databases/listing.json" }}
-{{- end}}
+{{- if .Values.anchoreEnterpriseFeeds.url -}}
+  {{- $urlPathSuffix := (default "" (regexFind "/v1.*$" .Values.anchoreEnterpriseFeeds.url)) -}}
+  {{- $anchoreFeedsHost := (trimSuffix $urlPathSuffix .Values.anchoreEnterpriseFeeds.url) -}}
+  {{- $anchoreFeedsURL = (printf "%s/v1/feeds" $anchoreFeedsHost) -}}
+  {{- $grypeProviderFeedsExternalURL = (printf "%s/v1/databases/grype" $anchoreFeedsHost) -}}
+{{- else if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
+  {{- if .Values.anchoreGlobal.internalServicesSsl.enabled -}}
+    {{- $anchoreFeedsURL = (printf "https://%s:%s/v1/feeds"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) -}}
+    {{- $grypeProviderFeedsExternalURL = (printf "https://%s:%s/v1/databases/grype"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) -}}
+  {{- else -}}
+    {{- $anchoreFeedsURL = (printf "http://%s:%s/v1/feeds" (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) -}}
+    {{- $grypeProviderFeedsExternalURL = (printf "http://%s:%s/v1/databases/grype"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) -}}
+  {{- end -}}
+{{- end -}}
 
 kind: ConfigMap
 apiVersion: v1
@@ -251,7 +245,7 @@ data:
               # grypedb feed is synced if the provider is set to grype. All the remaining feeds except for packages are ignored even if they are enabled
               grypedb:
                 enabled: {{ default "true" (.Values.anchoreGlobal.syncGrypeDB | quote) }}
-                url: {{default "https://toolbox-data.anchore.io/grype/databases/listing.json" $grypeProviderFeedsExternalURL}}
+                url: {{ $grypeProviderFeedsExternalURL }}
               # The following feeds are synced if provider is set to legacy
               # Vulnerabilities feed is the feed for distro cve sources (redhat, debian, ubuntu, oracle, alpine....)
               vulnerabilities:

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -9,6 +9,19 @@
 {{- end }}
 {{- end }}
 
+{{ $grypeProviderFeedsExternalURL := "" }}
+{{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
+{{- if .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL }}
+{{- $grypeProviderFeedsExternalURL = (printf "%s/databases/grype" .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL) }}
+{{- else if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+{{- $grypeProviderFeedsExternalURL = (printf "https://%s:%s/v1/databases/grype"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
+{{- else }}
+{{- $grypeProviderFeedsExternalURL = (printf "http://%s:%s/v1/databases/grype"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
+{{- end }}
+{{ - else }}
+{{- $grypeProviderFeedsExternalURL = "https://toolbox-data.anchore.io/grype/databases/listing.json" }}
+{{- end}}
+
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -237,8 +250,8 @@ data:
             data:
               # grypedb feed is synced if the provider is set to grype. All the remaining feeds except for packages are ignored even if they are enabled
               grypedb:
-                enabled: true
-                url: "https://toolbox-data.anchore.io/grype/databases/listing.json"
+                enabled: {{ default "true" (.Values.anchoreGlobal.syncGrypeDB | quote) }}
+                url: {{default "https://toolbox-data.anchore.io/grype/databases/listing.json" $grypeProviderFeedsExternalURL}}
               # The following feeds are synced if provider is set to legacy
               # Vulnerabilities feed is the feed for distro cve sources (redhat, debian, ubuntu, oracle, alpine....)
               vulnerabilities:

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -1,5 +1,15 @@
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
 {{- $component := "enterprise-feeds" -}}
+
+{{ $grypeProviderFeedsExternalURL := "" }}
+{{- if .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL }}
+{{- $grypeProviderFeedsExternalURL = .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL }}
+{{- else if .Values.anchoreGlobal.internalServicesSsl.enabled }}
+{{- $grypeProviderFeedsExternalURL = (printf "https://%s:%s/v1"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
+{{- else }}
+{{- $grypeProviderFeedsExternalURL = (printf "http://%s:%s/v1"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
+{{- end }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -142,7 +152,7 @@ data:
           {{- end }}
           grypedb:
             enabled: {{ default "true" (.Values.anchoreEnterpriseFeeds.grypeDriverEnabled | quote) }}
-            external_feeds_url: "https://toolbox-data.anchore.io/grype/databases/listing.json"
+            external_feeds_url: {{ $feedsExternalURL }}
         {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
         ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
         ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -1,14 +1,19 @@
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled -}}
 {{- $component := "enterprise-feeds" -}}
 
-{{ $grypeProviderFeedsExternalURL := "" }}
-{{- if .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL }}
-{{- $grypeProviderFeedsExternalURL = .Values.anchoreEnterpriseFeeds.grypeProviderFeedsExternalURL }}
-{{- else if .Values.anchoreGlobal.internalServicesSsl.enabled }}
-{{- $grypeProviderFeedsExternalURL = (printf "https://%s:%s/v1"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
-{{- else }}
-{{- $grypeProviderFeedsExternalURL = (printf "http://%s:%s/v1"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) }}
-{{- end }}
+{{- $grypeProviderFeedsExternalURL := "" -}}
+
+{{- if .Values.anchoreEnterpriseFeeds.url -}}
+  {{- $urlPathSuffix := (default "" (regexFind "/v1.*$" .Values.anchoreEnterpriseFeeds.url)) }}
+  {{- $anchoreFeedsHost := (trimSuffix $urlPathSuffix .Values.anchoreEnterpriseFeeds.url) -}}
+  {{- $grypeProviderFeedsExternalURL = (printf "%s/v1/" $anchoreFeedsHost) -}}
+{{- else -}}
+  {{- if .Values.anchoreGlobal.internalServicesSsl.enabled -}}
+    {{- $grypeProviderFeedsExternalURL = (printf "https://%s:%s/v1/"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) -}}
+  {{- else -}}
+    {{- $grypeProviderFeedsExternalURL = (printf "http://%s:%s/v1/"  (include "anchore-engine.enterprise-feeds.fullname" .) (.Values.anchoreEnterpriseFeeds.service.port | toString) ) -}}
+  {{- end -}}
+{{- end -}}
 
 apiVersion: v1
 kind: ConfigMap
@@ -152,7 +157,7 @@ data:
           {{- end }}
           grypedb:
             enabled: {{ default "true" (.Values.anchoreEnterpriseFeeds.grypeDriverEnabled | quote) }}
-            external_feeds_url: {{ $feedsExternalURL }}
+            external_feeds_url: {{ $grypeProviderFeedsExternalURL }}
         {{- if .Values.anchoreGlobal.internalServicesSsl.enabled }}
         ssl_enable: {{ .Values.anchoreGlobal.internalServicesSsl.enabled }}
         ssl_cert: "/home/anchore/certs/{{- .Values.anchoreGlobal.internalServicesSsl.certSecretCertName }}"

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -738,8 +738,12 @@ anchoreEnterpriseFeeds:
   # If enabled is set to false, set anchore-feeds-db.enabled to false to ensure that helm doesn't stand up a unneccessary postgres instance.
   enabled: true
 
-  # Set custom feeds URL if multiple Anchore deployments are using the same internal feeds service.
+  # Set custom feeds URL if multiple Anchore deployments are using the same internal feeds service. i.e.: https://<feeds-hostname>:<feeds-port>/v1/feeds
   url: ""
+
+  # ONLY USED IF RUNNING THE GRYPE PROVIDER: 
+  # The URL of the feeds service to download Grype DB with enterprise feeds, i.e.: https://<feeds-hostname>:<feeds-port>/v1/
+  grypeProviderFeedsExternalURL: ""
 
   # Enable github advisory feeds
   githubDriverEnabled: false

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -738,12 +738,9 @@ anchoreEnterpriseFeeds:
   # If enabled is set to false, set anchore-feeds-db.enabled to false to ensure that helm doesn't stand up a unneccessary postgres instance.
   enabled: true
 
-  # Set custom feeds URL if multiple Anchore deployments are using the same internal feeds service. i.e.: https://<feeds-hostname>:<feeds-port>/v1/feeds
+  # Set custom feeds URL. Useful when using a feeds service endpoint that is external from the cluster.
+  # i.e. https://<feeds-hostname>:<feeds-port>
   url: ""
-
-  # ONLY USED IF RUNNING THE GRYPE PROVIDER: 
-  # The URL of the feeds service to download Grype DB with enterprise feeds, i.e.: https://<feeds-hostname>:<feeds-port>/v1/
-  grypeProviderFeedsExternalURL: ""
 
   # Enable github advisory feeds
   githubDriverEnabled: false


### PR DESCRIPTION
# Operating Logic
## Policy Engine:
1. If enterprise feeds is NOT configured in helm chart:
	1. Use toolbox service s3
2. Else if enterprise feeds is configured in helm chart:
	1. If manual override is provided, use that
	2. Else build from feeds configuration

## Feeds Service
	1. If manual override is provided, use that
	2. Else build from feeds configuration