### PR TITLE
Expose the kubernetes request timeout parameter

### DIFF
--- a/stable/kai/templates/configmap.yaml
+++ b/stable/kai/templates/configmap.yaml
@@ -22,6 +22,7 @@ data:
       {{- toYaml .Values.kai.namespaces | nindent 6 }}
     mode: {{ .Values.kai.mode }}
     polling-interval-seconds: {{ .Values.kai.pollingIntervalSeconds }}
+    kubernetes-request-timeout-seconds: {{ .Values.kai.kubernetesRequestTimeoutSeconds }}
     anchore:
       url: {{ .Values.kai.anchore.url }}
       user: {{ .Values.kai.anchore.user }}

--- a/stable/kai/values.yaml
+++ b/stable/kai/values.yaml
@@ -109,6 +109,9 @@ kai:
   # Only respected if mode is periodic
   pollingIntervalSeconds: 60
 
+  # Configure the request timeout for the k8s api interaction
+  kubernetesRequestTimeoutSeconds: 60
+
   anchore:
     url:
 


### PR DESCRIPTION
Expose one of the configuration parameters for kai so the k8s api requests are configurable

Signed-off-by: James Petersen <jpetersenames@gmail.com>