### PR TITLE
Honor the timeout seconds config in kai

### DIFF
--- a/stable/kai/Chart.yaml
+++ b/stable/kai/Chart.yaml
@@ -28,7 +28,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/kai/templates/configmap.yaml
+++ b/stable/kai/templates/configmap.yaml
@@ -30,4 +30,4 @@ data:
       account: {{ .Values.kai.anchore.account }}
       http:
         insecure: {{ .Values.kai.anchore.http.insecure }}
-        timeoutSeconds: {{ .Values.kai.anchore.http.timeoutSeconds }}
+        timeout-seconds: {{ .Values.kai.anchore.http.timeoutSeconds }}


### PR DESCRIPTION
Honor the timeout-seconds config, the way it was set up in the configmap the app would silently fail to read the config option.