### PR TITLE
update the existing secret comment for db secret

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.16.1
+version: 1.16.2
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -789,6 +789,7 @@ anchoreEnterpriseFeeds:
   # ANCHORE_ADMIN_PASSWORD
   # ANCHORE_FEEDS_DB_PASSWORD
   # ANCHORE_SAML_SECRET (if applicable)
+  # ANCHORE_GITHUB_TOKEN (if applicable)
 
   existingSecret: Null
 


### PR DESCRIPTION
Updated the comment for the feeds database existing secret to reflect that the ANCHORE_GITHUB_TOKEN is a required field if using the the `existingSecret`.

Signed-off-by: James Petersen <jpetersenames@gmail.com>