### PR TITLE
Fix anchoreGlobal.scratchVolume

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.16.2
+version: 1.16.3
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/analyzer_deployment.yaml
+++ b/stable/anchore-engine/templates/analyzer_deployment.yaml
@@ -195,7 +195,11 @@ spec:
           configMap:
             name: {{ template "anchore-engine.fullname" .}}
         - name: {{ $component }}-scratch
-          {{ toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- if .Values.anchoreGlobal.scratchVolume.details }}
+          {{- toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
         - name: analyzer-config-volume
           configMap:
             name: {{ template "anchore-engine.analyzer.fullname" . }}

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -179,7 +179,11 @@ spec:
           configMap:
             name: {{ template "anchore-engine.enterprise-feeds.fullname" . }}
         - name: {{ $component}}-scratch
-          {{ toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- if .Values.anchoreGlobal.scratchVolume.details }}
+          {{- toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.anchoreGlobal.openShiftDeployment }}
         - name: service-config-volume
           emptyDir: {}

--- a/stable/anchore-engine/templates/policy_engine_deployment.yaml
+++ b/stable/anchore-engine/templates/policy_engine_deployment.yaml
@@ -191,7 +191,11 @@ spec:
           configMap:
             name: {{ template "anchore-engine.fullname" . }}
         - name: {{ $component }}-scratch
-          {{ toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- if .Values.anchoreGlobal.scratchVolume.details }}
+          {{- toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.anchoreGlobal.openShiftDeployment }}
         - name: service-config-volume
           emptyDir: {}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -141,9 +141,8 @@ anchoreGlobal:
     # fixup the permissions.
     fixGroupPermissions: false
     mountPath: /analysis_scratch
-    details:
+    details: {}
       # Specify volume configuration here
-      emptyDir: {}
 
   # A secret must be created in the same namespace as anchore-engine is deployed, containing the certificates & public/private keys used for SSL, SAML & custom CAs.
   # Certs and keys should be added using the file name the certificate is stored at. This secret will be mounted to /home/anchore/certs.


### PR DESCRIPTION
Scratch volume details were always adding emptyDir: {} due to the values being merged instead of overwritten
see - https://github.com/helm/helm/issues/1966

* Fix - use a conditional in scratchVolume configuration to set emptyDir instead
of expecting it use a default value

Signed-off-by: Brady Todhunter <bradyt@anchore.com>