### PR TITLE
Remove inaccurate checksum when existingSecret

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.18.0
+version: 1.18.1
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/analyzer_deployment.yaml
+++ b/stable/anchore-engine/templates/analyzer_deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- with .Values.anchoreAnalyzer.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not .Values.inject_secrets_via_env }}
+      {{- if not (or .Values.inject_secrets_via_env .Values.anchoreGlobal.existingSecret) }}
         checksum/secrets: {{ include (print $.Template.BasePath "/engine_secret.yaml") . | sha256sum }}
       {{- end }}
         checksum/env: {{ include (print $.Template.BasePath "/engine_configmap_env.yaml") . | sha256sum }}

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- with .Values.anchoreEnterpriseFeeds.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not .Values.inject_secrets_via_env }}
+      {{- if not (or .Values.inject_secrets_via_env .Values.anchoreEnterpriseUi.existingSecret) }}
         checksum/secrets: {{ include (print $.Template.BasePath "/enterprise_feeds_secret.yaml") . | sha256sum }}
       {{- end }}
         checksum/env: {{ include (print $.Template.BasePath "/enterprise_feeds_configmap_env.yaml") . | sha256sum }}

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- with .Values.anchoreEnterpriseFeeds.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not (or .Values.inject_secrets_via_env .Values.anchoreEnterpriseUi.existingSecret) }}
+      {{- if not (or .Values.inject_secrets_via_env .Values.anchoreEnterpriseFeeds.existingSecret) }}
         checksum/secrets: {{ include (print $.Template.BasePath "/enterprise_feeds_secret.yaml") . | sha256sum }}
       {{- end }}
         checksum/env: {{ include (print $.Template.BasePath "/enterprise_feeds_configmap_env.yaml") . | sha256sum }}

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- with .Values.anchoreEnterpriseUi.annotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not .Values.inject_secrets_via_env }}
+      {{- if not (or .Values.inject_secrets_via_env .Values.anchoreEnterpriseUi.existingSecret) }}
         checksum/secrets: {{ include (print $.Template.BasePath "/enterprise_ui_secret.yaml") . | sha256sum }}
       {{- end }}
         checksum/ui-config: {{ include (print $.Template.BasePath "/enterprise_ui_configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
When the .Values.anchoreEnterpriseUi.existingSecret is set, ignore the injection of the checksum because it will be inaccurate.

Fixes #197 