### PR TITLE
Check for actual ingress object in api version checks

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.18.2
+version: 1.18.1
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.18.1
+version: 1.18.3
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/ingress.yaml
+++ b/stable/anchore-engine/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1
@@ -45,7 +45,7 @@ spec:
       http:
         paths:
         - path: {{ $.Values.ingress.apiPath }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:
@@ -63,7 +63,7 @@ spec:
       http:
         paths:
         - path: {{ $.Values.ingress.uiPath }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:
@@ -81,7 +81,7 @@ spec:
       http:
         paths:
         - path: {{ $.Values.ingress.feedsPath }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:
@@ -99,7 +99,7 @@ spec:
       http:
         paths:
         - path: {{ $.Values.ingress.reportsPath }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:
@@ -117,7 +117,7 @@ spec:
         paths:
         {{- with .Values.ingress.apiPath }}
         - path: {{ . }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:
@@ -132,7 +132,7 @@ spec:
         {{- end }}
         {{- with .Values.ingress.uiPath }}
         - path: {{ . }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:
@@ -147,7 +147,7 @@ spec:
         {{- end }}
         {{- with .Values.ingress.feedsPath }}
         - path: {{ . }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:
@@ -162,7 +162,7 @@ spec:
         {{- end }}
         {{- with .Values.ingress.reportsPath }}
         - path: {{ . }}
-          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           pathType: Prefix
           backend:
             service:


### PR DESCRIPTION
On older versions of kubernetes the `networking.k8s.io/v1` API exists however the ingress object is not present. Simply checking for the existence of the API will cause the conditional to incorrectly set the `apiVersion`. Helm has the capability to check for the object itself so this PR just updates the check for the Ingress object.

https://helm.sh/docs/chart_template_guide/builtin_objects/#helm

> Capabilities.APIVersions.Has $version indicates whether a version (e.g., batch/v1) or resource (e.g., apps/v1/Deployment) is available on the cluster.

Signed-off-by: James Petersen <jpetersenames@gmail.com>