### PR TITLE
fix: ingress class shouldn't be set by default

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.18.6
+version: 1.18.7
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -85,7 +85,7 @@ ingress:
   #   - anchore-api.example.com
   annotations:
     # kubernetes.io/ingress.class: gce
-    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class: nginx
     # nginx.ingress.kubernetes.io/ssl-redirect: "false"
     # kubernetes.io/ingress.allow-http: false
     # kubernetes.io/tls-acme: true


### PR DESCRIPTION
Ingress class shouldn't be set by default, and if we were to enable one by default we should enable ingressClassName since the annotations is deprecated

Signed-off-by: sfroment <sfroment42@gmail.com>
