### PR TITLE
updating redis version from 10 to 16.11.3

### DIFF
--- a/stable/anchore-engine/Chart.lock
+++ b/stable/anchore-engine/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.9.0
-digest: sha256:b47e602eda542006b955de605c50598d188c3cbf5f4516847c1755310c048d29
-generated: "2022-06-03T09:48:26.068871-04:00"
+digest: sha256:1db3ab8a332664af77a5d7bb79216646595ce4ce582e2c4d7cfd3965a2d42ecc
+generated: "2022-06-03T18:03:29.6425-04:00"

--- a/stable/anchore-engine/Chart.lock
+++ b/stable/anchore-engine/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.0.1
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.9.0
-digest: sha256:1db3ab8a332664af77a5d7bb79216646595ce4ce582e2c4d7cfd3965a2d42ecc
-generated: "2022-06-03T18:03:29.6425-04:00"
+  version: 16.11.3
+digest: sha256:5bdfacf8fe535b57e509811f1a4e4f5563905ca74e205c2547ef6eb7b71972a5
+generated: "2022-06-07T02:10:46.327103-07:00"

--- a/stable/anchore-engine/Chart.lock
+++ b/stable/anchore-engine/Chart.lock
@@ -12,4 +12,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 16.9.0
 digest: sha256:b47e602eda542006b955de605c50598d188c3cbf5f4516847c1755310c048d29
-generated: "2022-06-02T20:46:06.723716+05:30"
+generated: "2022-06-03T09:48:26.068871-04:00"

--- a/stable/anchore-engine/Chart.lock
+++ b/stable/anchore-engine/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.0.1
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 10.9.0
-digest: sha256:44c16b3d5756edfaa4d86b8e57e6047de3ac0672d932f5cdf9fe1f28220b4fb0
-generated: "2021-09-29T23:16:53.207614-07:00"
+  version: 16.9.0
+digest: sha256:b47e602eda542006b955de605c50598d188c3cbf5f4516847c1755310c048d29
+generated: "2022-06-02T20:46:06.723716+05:30"

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.19.1
+version: 1.19.0
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
    condition: anchore-feeds-gem-db.enabled,anchoreEnterpriseFeeds.gemDriverEnabled
    alias: anchore-feeds-gem-db
  - name: redis
-   version: "16.9.0"
+   version: "16.11.3"
    repository: "https://charts.bitnami.com/bitnami"
    condition: ui-redis.enabled,anchoreEnterpriseGlobal.enabled
    alias: ui-redis

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.19.0
+version: 1.19.1
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.18.7
+version: 1.18.8
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:
@@ -38,7 +38,7 @@ dependencies:
    condition: anchore-feeds-gem-db.enabled,anchoreEnterpriseFeeds.gemDriverEnabled
    alias: anchore-feeds-gem-db
  - name: redis
-   version: "10"
+   version: "16.9.0"
    repository: "https://charts.bitnami.com/bitnami"
    condition: anchore-ui-redis.enabled,anchoreEnterpriseGlobal.enabled
    alias: anchore-ui-redis

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.18.8
+version: 1.19.0
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -40,5 +40,5 @@ dependencies:
  - name: redis
    version: "16.9.0"
    repository: "https://charts.bitnami.com/bitnami"
-   condition: anchore-ui-redis.enabled,anchoreEnterpriseGlobal.enabled
-   alias: anchore-ui-redis
+   condition: ui-redis.enabled,anchoreEnterpriseGlobal.enabled
+   alias: ui-redis

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -135,7 +135,6 @@ anchore-feeds-db:
     size: 20Gi
 
 ui-redis:
-  password: <PASSWORD>
   auth:
     password: <PASSWORD>
 ```
@@ -234,7 +233,6 @@ anchore-feeds-db:
       size: 50Gi
 
 ui-redis:
-  password: <PASSWORD>
   auth:
     password: <PASSWORD>
 ```
@@ -249,12 +247,12 @@ A Helm post-upgrade hook job will shut down all previously running Anchore servi
 
 The upgrade will only be considered successful when this job completes successfully. Performing an upgrade will cause the Helm client to block until the upgrade job completes and the new Anchore service pods are started. To view progress of the upgrade process, tail the logs of the upgrade jobs `anchore-engine-upgrade` and `anchore-enterprise-upgrade`. These job resources will be removed upon a successful Helm upgrade.
 
-## Chart version 1.19.0
+## Chart version 1.19.1
 
 * Redis chart updated from version 10 to 16.9.0 updated to the latest version as bitnami has started removing older version of their charts.
 * * redis will by default run in the `standalone` architecture.
 * `anchore-ui-redis` in the helm values should now be `ui-redis`
-* * if you've set the the `password` value under `anchore-ui-redis`, you will now have to set the `auth.password` as well, making the end change `ui-redis.auth.password` and `ui-redis.password` should be set. Not setting both will result in the ui not being able to reach the reporting services.
+* * if you've set the the `password` value under `anchore-ui-redis`, you will now have to change it to `auth.password`, making the end change `ui-redis.auth.password`
 
 * WARNING: Users may be logged out from the platform after this happens since this will delete the old redis deployment and spin up a new one in its place
   * For more information on why this is necessary, see [the breaking change here](https://github.com/bitnami/charts/tree/master/bitnami/redis/#to-1400)

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -136,6 +136,8 @@ anchore-feeds-db:
 
 ui-redis:
   password: <PASSWORD>
+  auth:
+    password: <PASSWORD>
 ```
 
 ## Installing on OpenShift
@@ -233,6 +235,8 @@ anchore-feeds-db:
 
 ui-redis:
   password: <PASSWORD>
+  auth:
+    password: <PASSWORD>
 ```
 
 # Chart Updates
@@ -244,6 +248,16 @@ See the anchore-engine [CHANGELOG](https://github.com/anchore/anchore-engine/blo
 A Helm post-upgrade hook job will shut down all previously running Anchore services and perform the Anchore database upgrade process using a Kubernetes job.
 
 The upgrade will only be considered successful when this job completes successfully. Performing an upgrade will cause the Helm client to block until the upgrade job completes and the new Anchore service pods are started. To view progress of the upgrade process, tail the logs of the upgrade jobs `anchore-engine-upgrade` and `anchore-enterprise-upgrade`. These job resources will be removed upon a successful Helm upgrade.
+
+## Chart version 1.19.0
+
+* Redis chart updated from version 10 to 16.9.0 updated to the latest version as bitnami has started removing older version of their charts.
+* * redis will by default run in the `standalone` architecture.
+* `anchore-ui-redis` in the helm values should now be `ui-redis`
+* * if you've set the the `password` value under `anchore-ui-redis`, you will now have to set the `auth.password` as well, making the end change `ui-redis.auth.password` and `ui-redis.password` should be set. Not setting both will result in the ui not being able to reach the reporting services.
+
+* WARNING: Users may be logged out from the platform after this happens since this will delete the old redis deployment and spin up a new one in its place
+  * For more information on why this is necessary, see [the breaking change here](https://github.com/bitnami/charts/tree/master/bitnami/redis/#to-1400)
 
 ## Chart version 1.18.0
 

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -247,7 +247,7 @@ A Helm post-upgrade hook job will shut down all previously running Anchore servi
 
 The upgrade will only be considered successful when this job completes successfully. Performing an upgrade will cause the Helm client to block until the upgrade job completes and the new Anchore service pods are started. To view progress of the upgrade process, tail the logs of the upgrade jobs `anchore-engine-upgrade` and `anchore-enterprise-upgrade`. These job resources will be removed upon a successful Helm upgrade.
 
-## Chart version 1.19.1
+## Chart version 1.19.0
 
 * Redis chart updated from version 10 to 16.9.0 updated to the latest version as bitnami has started removing older version of their charts.
 * * redis will by default run in the `standalone` architecture.

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -249,7 +249,7 @@ The upgrade will only be considered successful when this job completes successfu
 
 ## Chart version 1.19.0
 
-* Redis chart updated from version 10 to 16.9.0 updated to the latest version as bitnami has started removing older version of their charts.
+* Redis chart updated from version 10 to 16.11.3 updated to the latest version as bitnami has started removing older version of their charts.
 * redis will by default run in the `standalone` architecture.
 * `anchore-ui-redis` in the helm values should now be `ui-redis`
   * if you've set the the `password` value under `anchore-ui-redis`, you will now have to change it to `auth.password`, making the end change `ui-redis.auth.password`

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -134,7 +134,7 @@ anchore-feeds-db:
   persistence:
     size: 20Gi
 
-anchore-ui-redis:
+ui-redis:
   password: <PASSWORD>
 ```
 
@@ -231,7 +231,7 @@ anchore-feeds-db:
     persistence:
       size: 50Gi
 
-anchore-ui-redis:
+ui-redis:
   password: <PASSWORD>
 ```
 
@@ -416,7 +416,7 @@ release "my-anchore" uninstalled
 Anchore Enterprise users will want to remove the Redis DB PersistentVolumeClaim. This will delete all current session data but will not affect stability of the deployment:
 
 ```bash
-kubectl delete pvc redis-data-my-anchore-anchore-ui-redis-master-0
+kubectl delete pvc redis-data-my-anchore-ui-redis-master-0
 ```
 
 Your other PersistentVolumeClaims will still be resident in your cluster (we're showing results from an Anchore Enterprise installation that has a standalone Feeds Service below. Anchore Enterprise users without a standalone Feeds Service, and Anchore Engine users will not see `my-anchore-anchore-feeds-db`):

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -250,9 +250,9 @@ The upgrade will only be considered successful when this job completes successfu
 ## Chart version 1.19.0
 
 * Redis chart updated from version 10 to 16.9.0 updated to the latest version as bitnami has started removing older version of their charts.
-* * redis will by default run in the `standalone` architecture.
+* redis will by default run in the `standalone` architecture.
 * `anchore-ui-redis` in the helm values should now be `ui-redis`
-* * if you've set the the `password` value under `anchore-ui-redis`, you will now have to change it to `auth.password`, making the end change `ui-redis.auth.password`
+  * if you've set the the `password` value under `anchore-ui-redis`, you will now have to change it to `auth.password`, making the end change `ui-redis.auth.password`
 
 * WARNING: Users may be logged out from the platform after this happens since this will delete the old redis deployment and spin up a new one in its place
   * For more information on why this is necessary, see [the breaking change here](https://github.com/bitnami/charts/tree/master/bitnami/redis/#to-1400)

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Create a default fully qualified dependency name for the db.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "redis.fullname" -}}
-{{- printf "%s-%s" .Release.Name "anchore-ui-redis" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name "ui-redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -89,7 +89,7 @@ spec:
         env:
         {{- if and (not (index .Values "anchoreEnterpriseUi" "existingSecret")) (not (index .Values "ui-redis" "externalEndpoint")) }}
         - name: ANCHORE_REDIS_URI
-          value: redis://nouser:{{ index .Values "ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379
+          value: redis://nouser:{{ index .Values "ui-redis" "auth" "password" }}@{{ template "redis.fullname" . }}-master:6379
         {{- end }}
         {{ if .Values.anchoreGlobal.dbConfig.ssl }}
         - name: PGSSLROOTCERT

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -87,9 +87,9 @@ spec:
         image: {{ .Values.anchoreEnterpriseUi.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseUi.imagePullPolicy }}
         env:
-        {{- if and (index .Values "anchoreEnterpriseUi" "existingSecret") (not (index .Values "anchore-ui-redis" "externalEndpoint")) }}
+        {{- if and (index .Values "anchoreEnterpriseUi" "existingSecret") (not (index .Values "ui-redis" "externalEndpoint")) }}
         - name: ANCHORE_REDIS_URI
-          value: redis://nouser:{{ index .Values "anchore-ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379
+          value: redis://nouser:{{ index .Values "ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379
         {{- end }}
         {{ if .Values.anchoreGlobal.dbConfig.ssl }}
         - name: PGSSLROOTCERT

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -87,7 +87,7 @@ spec:
         image: {{ .Values.anchoreEnterpriseUi.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseUi.imagePullPolicy }}
         env:
-        {{- if and (index .Values "anchoreEnterpriseUi" "existingSecret") (not (index .Values "ui-redis" "externalEndpoint")) }}
+        {{- if and (not (index .Values "anchoreEnterpriseUi" "existingSecret")) (not (index .Values "ui-redis" "externalEndpoint")) }}
         - name: ANCHORE_REDIS_URI
           value: redis://nouser:{{ index .Values "ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379
         {{- end }}

--- a/stable/anchore-engine/templates/enterprise_ui_secret.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_secret.yaml
@@ -20,10 +20,10 @@ stringData:
   ANCHORE_APPDB_URI: 'postgresql://{{ index .Values "postgresql" "postgresUser" }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}'
   {{- end }}
 
-  {{- if and (index .Values "anchore-ui-redis" "externalEndpoint") (not (index .Values "anchore-ui-redis" "enabled")) }}
-  ANCHORE_REDIS_URI: '{{ index .Values "anchore-ui-redis" "externalEndpoint" }}'
+  {{- if and (index .Values "ui-redis" "externalEndpoint") (not (index .Values "ui-redis" "enabled")) }}
+  ANCHORE_REDIS_URI: '{{ index .Values "ui-redis" "externalEndpoint" }}'
   {{- else }}
-  ANCHORE_REDIS_URI: 'redis://nouser:{{ index .Values "anchore-ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379'
+  ANCHORE_REDIS_URI: 'redis://nouser:{{ index .Values "ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379'
   {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/enterprise_ui_secret.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_secret.yaml
@@ -23,7 +23,7 @@ stringData:
   {{- if and (index .Values "ui-redis" "externalEndpoint") (not (index .Values "ui-redis" "enabled")) }}
   ANCHORE_REDIS_URI: '{{ index .Values "ui-redis" "externalEndpoint" }}'
   {{- else }}
-  ANCHORE_REDIS_URI: 'redis://nouser:{{ index .Values "ui-redis" "password" }}@{{ template "redis.fullname" . }}-master:6379'
+  ANCHORE_REDIS_URI: 'redis://nouser:{{ index .Values "ui-redis" "auth" "password" }}@{{ template "redis.fullname" . }}-master:6379'
   {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1195,8 +1195,7 @@ anchoreEnterpriseUi:
 # Only utilized if 'anchoreEnterpriseUi.enabled: true'
 anchore-ui-redis:
   password: anchore-redis,123
-  cluster:
-    enabled: false
+  architecture: standalone
   persistence:
     enabled: false
 

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1030,7 +1030,7 @@ anchoreEnterpriseNotifications:
 
 # Configure the Anchore Enterprise UI.
 anchoreEnterpriseUi:
-  # If enabled is set to false, set anchore-ui-redis.enabled to false to ensure that helm doesn't stand up a unneccessary redis instance.
+  # If enabled is set to false, set ui-redis.enabled to false to ensure that helm doesn't stand up a unneccessary redis instance.
   enabled: true
   image: docker.io/anchore/enterprise-ui:v4.0.0
   imagePullPolicy: IfNotPresent
@@ -1193,7 +1193,7 @@ anchoreEnterpriseUi:
 
 # Anchore Engine Enterprise UI is dependent on redis for storing sessions
 # Only utilized if 'anchoreEnterpriseUi.enabled: true'
-anchore-ui-redis:
+ui-redis:
   password: anchore-redis,123
   architecture: standalone
   persistence:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1194,6 +1194,8 @@ anchoreEnterpriseUi:
 # Anchore Engine Enterprise UI is dependent on redis for storing sessions
 # Only utilized if 'anchoreEnterpriseUi.enabled: true'
 ui-redis:
+  auth:
+    password: anchore-redis,123
   password: anchore-redis,123
   architecture: standalone
   persistence:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1197,8 +1197,9 @@ ui-redis:
   auth:
     password: anchore-redis,123
   architecture: standalone
-  persistence:
-    enabled: false
+  master:
+    persistence:
+      enabled: false
 
   # To use an external redis endpoint, uncomment to set 'enabled: false'
   # enabled: false

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1196,7 +1196,6 @@ anchoreEnterpriseUi:
 ui-redis:
   auth:
     password: anchore-redis,123
-  password: anchore-redis,123
   architecture: standalone
   persistence:
     enabled: false


### PR DESCRIPTION
updating redis version from 10 to 16.11.3; set redis architecture to standalone by default

When upgrading, helm may throw an error: "Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden"

the work-around was deleting the statefulset and reconciling so that helm can recreate the statefulset.

Signed-off-by: Hung Nguyen <hung.nguyen@anchore.com>