### PR TITLE
Add scratch volume to catalog

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.19.2
+version: 1.19.3
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/catalog_deployment.yaml
+++ b/stable/anchore-engine/templates/catalog_deployment.yaml
@@ -73,6 +73,20 @@ spec:
       - name: {{ . }}
       {{- end }}
     {{- end }}
+    {{- if and .Values.anchoreGlobal.scratchVolume.fixGroupPermissions .Values.anchoreGlobal.securityContext.fsGroup }}
+      initContainers:
+        - name: mode-fixer
+          image: alpine
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: {{ $component }}-scratch
+              mountPath: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
+          command:
+            - sh
+            - -c
+            - (chmod 0775 {{ .Values.anchoreGlobal.scratchVolume.mountPath }}; chgrp {{ .Values.anchoreGlobal.securityContext.fsGroup }} {{ .Values.anchoreGlobal.scratchVolume.mountPath }} )
+      {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy
@@ -139,6 +153,8 @@ spec:
         - name: config-volume
           mountPath: /config/config.yaml
           subPath: config.yaml
+        - name: {{ $component }}-scratch
+          mountPath: {{ .Values.anchoreGlobal.scratchVolume.mountPath }}
         {{- if .Values.anchoreGlobal.policyBundles }}
         {{- range $key, $value := .Values.anchoreGlobal.policyBundles }}
         - name: policy-bundle-volume
@@ -193,6 +209,12 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "anchore-engine.fullname" . }}
+        - name: {{ $component }}-scratch
+        {{- if .Values.anchoreGlobal.scratchVolume.details }}
+          {{- toYaml .Values.anchoreGlobal.scratchVolume.details | nindent 10 }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.anchoreGlobal.policyBundles }}
         - name: policy-bundle-volume
           configMap:


### PR DESCRIPTION
Currently there is no way to mount the catalog scratch space as a volume. This means in read-only file systems we can't configure the scratch space to be writeable. This PR just adds the scratch volume config to the catalog deployment.