### PR TITLE
Switch KAI to XDG config

### DIFF
--- a/stable/kai/Chart.yaml
+++ b/stable/kai/Chart.yaml
@@ -28,11 +28,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.3.0
+appVersion: 0.3.2
 
 icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png

--- a/stable/kai/templates/configmap.yaml
+++ b/stable/kai/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  .kai.yaml: |
+  config.yaml: |
     kubeconfig:
       path: {{ .Values.kai.kubeconfig.path }}
       cluster: {{ .Values.kai.kubeconfig.cluster }}

--- a/stable/kai/templates/deployment.yaml
+++ b/stable/kai/templates/deployment.yaml
@@ -60,8 +60,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config-volume
-              mountPath: /home/nonroot/.kai.yaml
-              subPath: .kai.yaml
+              mountPath: /etc/xdg/kai/config.yaml
+              subPath: config.yaml
           envFrom:
             {{- if not .Values.inject_secrets_via_env }}
             - secretRef:

--- a/stable/kai/values.yaml
+++ b/stable/kai/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: anchore/kai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.3.0"
+  tag: "v0.3.2"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
When KAI runs on open shift clusters it will assign a random user. The
underlying viper code will fail when looking in /home/nonroot so the
config file should exist in $XDG_CONFIG_DIRS so the container can be run
as any user and still function properly

Signed-off-by: James Petersen <jpetersenames@gmail.com>