### PR TITLE
Adding implementation for separate ui database user

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.20.4
+version: 1.20.5
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/engine_configmap_env.yaml
+++ b/stable/anchore-engine/templates/engine_configmap_env.yaml
@@ -13,10 +13,4 @@ metadata:
 data:
   ANCHORE_DB_NAME: {{ index .Values "postgresql" "postgresDatabase" | quote }}
   ANCHORE_DB_USER: {{ index .Values "postgresql" "postgresUser" | quote }}
-  {{- if and (index .Values "postgresql" "externalEndpoint") (not (index .Values "postgresql" "enabled")) }}
-  ANCHORE_DB_HOST: {{ index .Values "postgresql" "externalEndpoint" | quote }}
-  {{- else if and (index .Values "cloudsql" "enabled") (not (index .Values "postgresql" "enabled")) }}
-  ANCHORE_DB_HOST: "localhost:5432"
-  {{- else }}
-  ANCHORE_DB_HOST: "{{ template "postgres.fullname" . }}:5432"
-  {{- end }}
+  ANCHORE_DB_HOST: "{{ template "db-hostname" . }}"

--- a/stable/anchore-engine/templates/enterprise_ui_secret.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_secret.yaml
@@ -15,9 +15,9 @@ metadata:
 type: Opaque
 stringData:
   {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-  ANCHORE_APPDB_URI: 'postgresql://{{ index .Values "postgresql" "postgresUser" }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}?ssl=verify-full'
+  ANCHORE_APPDB_URI: 'postgresql://{{ ternary (index .Values "anchoreEnterpriseUi" "dbUser") (index .Values "postgresql" "postgresUser") (hasKey .Values.anchoreEnterpriseUi "dbUser" ) }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}?ssl=verify-full'
   {{- else }}
-  ANCHORE_APPDB_URI: 'postgresql://{{ index .Values "postgresql" "postgresUser" }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}'
+  ANCHORE_APPDB_URI: 'postgresql://{{ ternary (index .Values "anchoreEnterpriseUi" "dbUser") (index .Values "postgresql" "postgresUser") (hasKey .Values.anchoreEnterpriseUi "dbUser" ) }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}'
   {{- end }}
 
   {{- if and (index .Values "ui-redis" "externalEndpoint") (not (index .Values "ui-redis" "enabled")) }}

--- a/stable/anchore-engine/templates/enterprise_ui_secret.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_secret.yaml
@@ -15,9 +15,9 @@ metadata:
 type: Opaque
 stringData:
   {{- if .Values.anchoreGlobal.dbConfig.ssl }}
-  ANCHORE_APPDB_URI: 'postgresql://{{ ternary (index .Values "anchoreEnterpriseUi" "dbUser") (index .Values "postgresql" "postgresUser") (hasKey .Values.anchoreEnterpriseUi "dbUser" ) }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}?ssl=verify-full'
+  ANCHORE_APPDB_URI: 'postgresql://{{ ternary (index .Values "anchoreEnterpriseUi" "dbUser") (index .Values "postgresql" "postgresUser") (hasKey .Values.anchoreEnterpriseUi "dbUser" ) }}:{{ ternary (index .Values "anchoreEnterpriseUi" "dbPass") (index .Values "postgresql" "postgresPassword") (hasKey .Values.anchoreEnterpriseUi "dbPass" ) }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}?ssl=verify-full'
   {{- else }}
-  ANCHORE_APPDB_URI: 'postgresql://{{ ternary (index .Values "anchoreEnterpriseUi" "dbUser") (index .Values "postgresql" "postgresUser") (hasKey .Values.anchoreEnterpriseUi "dbUser" ) }}:{{ index .Values "postgresql" "postgresPassword" }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}'
+  ANCHORE_APPDB_URI: 'postgresql://{{ ternary (index .Values "anchoreEnterpriseUi" "dbUser") (index .Values "postgresql" "postgresUser") (hasKey .Values.anchoreEnterpriseUi "dbUser" ) }}:{{ ternary (index .Values "anchoreEnterpriseUi" "dbPass") (index .Values "postgresql" "postgresPassword") (hasKey .Values.anchoreEnterpriseUi "dbPass" ) }}@{{ template "db-hostname" . }}/{{ index .Values "postgresql" "postgresDatabase" }}'
   {{- end }}
 
   {{- if and (index .Values "ui-redis" "externalEndpoint") (not (index .Values "ui-redis" "enabled")) }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1092,6 +1092,7 @@ anchoreEnterpriseUi:
   # Specify configurations for database connection user
   # This should specifically allow overriding and separation of the ui database user
   # dbUser: anchoreengineui
+  # dbPass: anchore-postgres,123ui
 
   # The (optional) `appdbConfig` key specifies the connection options
   # for the application SQL database.

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -1089,6 +1089,10 @@ anchoreEnterpriseUi:
   # ANCHORE_REDIS_URI
   existingSecret: Null
 
+  # Specify configurations for database connection user
+  # This should specifically allow overriding and separation of the ui database user
+  # dbUser: anchoreengineui
+
   # The (optional) `appdbConfig` key specifies the connection options
   # for the application SQL database.
   #


### PR DESCRIPTION
Closes #224 

Relates to #195 and #196 

Directly implements a configuration to allow overriding the enterpriseUI database user and providing separation for access to the database by Engine/UI to aid in traceability/logging/auditing.

Indirectly addresses some standardization of DB host across resource files. 

Willing to consider another templating mechanism outside of the ternary - it's self-documenting but not syntactically pretty. 