### PR TITLE
Admission controller v0.4.0

### DIFF
--- a/stable/anchore-admission-controller/Chart.yaml
+++ b/stable/anchore-admission-controller/Chart.yaml
@@ -1,8 +1,8 @@
 name: anchore-admission-controller
 description: A kubernetes admission controller for validating and mutating webhooks that operates against Anchore Engine to make access decisions and annotations
 apiVersion: v1
-appVersion: 0.3.0
-version: 0.3.0
+appVersion: 0.4.0
+version: 0.4.0
 home: https://github.com/anchore/kubernetes-admission-controller
 maintainers:
   - name: zhill
@@ -10,3 +10,4 @@ maintainers:
   - name: btodhunter
     email: bradyt@anchore.com
 icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png
+kubeVersion: ^1.19.0

--- a/stable/anchore-admission-controller/templates/deployment.yaml
+++ b/stable/anchore-admission-controller/templates/deployment.yaml
@@ -30,11 +30,11 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
-        - "/anchore-kubernetes-admission-controller"
+        - "/ko-app/kubernetes-admission-controller"
         - "--audit-log-path=-"
         - "--tls-cert-file=/var/serving-cert/tls.crt"
         - "--tls-private-key-file=/var/serving-cert/tls.key"
-        - "--v={{ .Values.logVerbosity }}"
+        - "-v{{ .Values.logVerbosity }}"
         - "--secure-port={{ .Values.service.internalPort }}"
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/stable/anchore-admission-controller/templates/init-ca/init-ca-script.yaml
+++ b/stable/anchore-admission-controller/templates/init-ca/init-ca-script.yaml
@@ -88,7 +88,7 @@ data:
       sed "s/TLS_SERVING_KEY/$(base64 ${CERT_DIR}/serving-{{ template "anchore-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc.key | tr -d '\n')/g" | kubectl -n {{ .Release.Namespace }} apply -f -
 
     cat > api-service.yaml <<EOF
-    apiVersion: apiregistration.k8s.io/v1beta1
+    apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
       name: {{ .Values.apiService.version }}.{{ .Values.apiService.group }}

--- a/stable/anchore-admission-controller/templates/webhook.yaml
+++ b/stable/anchore-admission-controller/templates/webhook.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiService.webhook.enabled }}
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ template "anchore-admission-controller.name" . }}-admission.anchore.io
@@ -18,4 +18,8 @@ webhooks:
     {{- toYaml .Values.apiService.webhook.rules | nindent 4}}
   failurePolicy: {{ .Values.apiService.webhook.failurePolicy }}
   namespaceSelector: {{- toYaml .Values.apiService.namespaceSelector | nindent 4 }}
+  sideEffects: None
+  admissionReviewVersions: 
+    - v1
+
 {{- end }}

--- a/stable/anchore-admission-controller/values.yaml
+++ b/stable/anchore-admission-controller/values.yaml
@@ -5,13 +5,13 @@
 replicaCount: 1
 logVerbosity: 3
 
-image: "anchore/kubernetes-admission-controller:v0.3.0"
+image: "anchore/kubernetes-admission-controller:v0.4.0"
 imagePullPolicy: IfNotPresent
 
 service:
   name: anchoreadmissioncontroller
   type: ClusterIP
-  internalPort: 443
+  internalPort: 8443
   externalPort: 443
 
 apiService:


### PR DESCRIPTION
Adds compatibility for k8s 1.22+ but also adds a kubeVersion constraint to the chart of 1.19+ to ensure old k8s versions don't fail trying to deploy this update.

For k8s clusters < 1.19, they should stick with the 0.3.x chart.