### PR TITLE
Add existing secret check

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.21.2
+version: 1.21.3
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -425,8 +425,20 @@ Create database hostname string from supplied values file. Used for setting the 
   {{- end }}
 {{- end }}
 
+{{/*
+Allows sourcing of a specified file in the entrypoint of all containers when .Values.anchoreGlobal.doSourceAtEntry.enabled=true
+*/}}
 {{- define "doSourceFile" }}
 {{- if .Values.anchoreGlobal.doSourceAtEntry.enabled }}
     {{- printf "source %v;" .Values.anchoreGlobal.doSourceAtEntry.filePath }}
+{{- end }}
+{{- end }}
+
+{{/*
+Upon upgrades, checks if .Values.existingSecret=true and fails the upgrade if .Values.useExistingSecret is not set.
+*/}}
+{{- define "checkUpgradeForExistingSecret" }}
+{{- if and .Release.IsUpgrade .Values.anchoreGlobal.existingSecret (not .Values.anchoreGlobal.useExistingSecrets) }}
+    {{- fail "WARNING: As of chart v1.21.0 `.Values.anchoreGlobal.existingSecret` is no longer a valid configuration value. See the chart README for more instructions on configuring existing secrets - https://github.com/anchore/anchore-charts/blob/main/stable/anchore-engine/README.md#chart-version-1210" }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/anchore_admin_secret.yaml
+++ b/stable/anchore-engine/templates/anchore_admin_secret.yaml
@@ -1,3 +1,4 @@
+{{- template "checkUpgradeForExistingSecret" . }}
 {{- if not .Values.anchoreGlobal.useExistingSecrets }}
 
 {{- $anchoreAdminPass := (include "anchore-engine.defaultAdminPassword" . | quote) }}

--- a/stable/anchore-engine/templates/engine_secret.yaml
+++ b/stable/anchore-engine/templates/engine_secret.yaml
@@ -1,3 +1,4 @@
+{{- template "checkUpgradeForExistingSecret" . }}
 {{- if not .Values.anchoreGlobal.useExistingSecrets }}
 apiVersion: v1
 kind: Secret

--- a/stable/anchore-engine/templates/enterprise_feeds_secret.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_secret.yaml
@@ -1,3 +1,4 @@
+{{- template "checkUpgradeForExistingSecret" . }}
 {{- if not .Values.anchoreGlobal.useExistingSecrets }}
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
 apiVersion: v1

--- a/stable/anchore-engine/templates/enterprise_ui_secret.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_secret.yaml
@@ -1,3 +1,4 @@
+{{- template "checkUpgradeForExistingSecret" . }}
 {{- if not .Values.anchoreGlobal.useExistingSecrets }}
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseUi.enabled }}
 apiVersion: v1


### PR DESCRIPTION
This will prevent users who have `anchoreGlobal.existingSecrets` set from a failed upgrade if they didn't update their values file and secrets for chart v1.21.0