### PR TITLE
add logic that checks for Enterprise v4.4.0 upgrade compatibility

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.22.0
+version: 1.22.1
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -450,9 +450,14 @@ upgrading from Enterprise 4.3.0 only and error out if they're upgrading from an 
 {{- define "checkUpgradeCompatibility" }}
 {{- if and .Release.IsUpgrade (regexMatch "1.22.[0-9]+" .Chart.Version) }}
     {{- $apiDeploymentContainers := (lookup "apps/v1" "Deployment" .Release.Namespace (include "anchore-engine.api.fullname" .)).spec.template.spec.containers }}
-    {{- $installedAnchoreVersion := (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+$" (index $apiDeploymentContainers 0).image | quote) }}
-    {{- if not (regexMatch "v4\\.[3-9]\\.[0-9]" $installedAnchoreVersion) }}
-        {{- fail "WARNING - Anchore Enterprise v4.4.0 only supports upgrades from Enterprise v4.3.0. See release notes for more information - https://docs.anchore.com/current/docs/releasenotes/440/" }}
+    {{- range $index, $container := $apiDeploymentContainers }}
+        {{- if eq $container.name "anchore-engine-api" }}
+            {{- $apiContainerImage := $container.image }}
+            {{- $installedAnchoreVersion := (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+$" $apiContainerImage | quote) }}
+            {{- if not (regexMatch "v4\\.[3-9]\\.[0-9]" $installedAnchoreVersion) }}
+            {{- fail "WARNING - Anchore Enterprise v4.4.0 only supports upgrades from Enterprise v4.3.0. See release notes for more information - https://docs.anchore.com/current/docs/releasenotes/440/" }}
+            {{- end }}
+        {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -445,7 +445,7 @@ Upon upgrades, checks if .Values.existingSecret=true and fails the upgrade if .V
 
 {{/*
 Upon upgrade, check if user is upgrading to chart v1.22.0+ (Enterprise v4.4.0). If they are, ensure that they are
-upgrading from Enterprise 4.3.0 only and error out if they're upgrading from an older version.
+upgrading from Enterprise 4.2.0 or higher and error out if they're upgrading from an older version.
 */}}
 {{- define "checkUpgradeCompatibility" }}
 {{- if and .Release.IsUpgrade (regexMatch "1.22.[0-9]+" .Chart.Version) }}
@@ -454,8 +454,8 @@ upgrading from Enterprise 4.3.0 only and error out if they're upgrading from an 
         {{- if eq $container.name "anchore-engine-api" }}
             {{- $apiContainerImage := $container.image }}
             {{- $installedAnchoreVersion := (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+$" $apiContainerImage | quote) }}
-            {{- if not (regexMatch "v4\\.[3-9]\\.[0-9]" $installedAnchoreVersion) }}
-            {{- fail "WARNING - Anchore Enterprise v4.4.0 only supports upgrades from Enterprise v4.3.0. See release notes for more information - https://docs.anchore.com/current/docs/releasenotes/440/" }}
+            {{- if not (regexMatch "v4\\.[2-9]\\.[0-9]" $installedAnchoreVersion) }}
+            {{- fail "WARNING - Anchore Enterprise v4.4.0 only supports upgrades from Enterprise v4.2.0 and higher. See release notes for more information - https://docs.anchore.com/current/docs/releasenotes/440/" }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -442,3 +442,17 @@ Upon upgrades, checks if .Values.existingSecret=true and fails the upgrade if .V
     {{- fail "WARNING: As of chart v1.21.0 `.Values.anchoreGlobal.existingSecret` is no longer a valid configuration value. See the chart README for more instructions on configuring existing secrets - https://github.com/anchore/anchore-charts/blob/main/stable/anchore-engine/README.md#chart-version-1210" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Upon upgrade, check if user is upgrading to chart v1.22.0+ (Enterprise v4.4.0). If they are, ensure that they are
+upgrading from Enterprise 4.3.0 only and error out if they're upgrading from an older version.
+*/}}
+{{- define "checkUpgradeCompatibility" }}
+{{- if and .Release.IsUpgrade (regexMatch "1.22.[0-9]+" .Chart.Version) }}
+    {{- $apiDeploymentContainers := (lookup "apps/v1" "Deployment" .Release.Namespace (include "anchore-engine.api.fullname" .)).spec.template.spec.containers }}
+    {{- $installedAnchoreVersion := (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+$" (index $apiDeploymentContainers 0).image | quote) }}
+    {{- if not (regexMatch "v4\\.[3-9]\\.[0-9]" $installedAnchoreVersion) }}
+        {{- fail "WARNING - Anchore Enterprise v4.4.0 only supports upgrades from Enterprise v4.3.0. See release notes for more information - https://docs.anchore.com/current/docs/releasenotes/440/" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -1,3 +1,4 @@
+{{- template "checkUpgradeCompatibility" . }}
 {{- if .Values.anchoreEngineUpgradeJob.enabled }}
 apiVersion: batch/v1
 kind: Job

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -1,3 +1,4 @@
+{{- template "checkUpgradeCompatibility" . }}
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled .Values.anchoreEnterpriseFeedsUpgradeJob.enabled }}
 apiVersion: batch/v1
 kind: Job

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -1,3 +1,4 @@
+{{- template "checkUpgradeCompatibility" . }}
 {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseEngineUpgradeJob.enabled }}
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
This adds an upgrade check to ensure customers don't end up with a failed database migration due to upgrade incompatibility found in Anchore Enterprise v4.4.0

I still need to do more testing on the different use cases that will trigger this logic. Also need to confirm all the regex to ensure it's checking for the _correct_ things.

Signed-off-by: Brady Todhunter <bradyt@anchore.com>