### PR TITLE
Fix dryrun upgrade

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.22.3
+version: 1.22.4
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/NOTES.txt
+++ b/stable/anchore-engine/templates/NOTES.txt
@@ -1,14 +1,26 @@
-{{- if not .Values.anchoreEnterpriseGlobal.enabled }}
-WARNING - As of 2023, Anchore Engine is no longer maintained. There will be no future versions released. Users are advised to use Syft and Grype.
-{{- end }}
-
 To use Anchore you need the URL, username, and password to access the API and/or the UI.
 
 Anchore can be accessed via port {{ .Values.anchoreApi.service.port }} on the following DNS name from within the cluster:
 {{ template "anchore-engine.api.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
-* NOTE: On first startup of Anchore, the policy-engine performs a CVE data sync which may take several minutes to complete. During this time the system status will report 'partially_down' and any images added for analysis will stay in the 'not_analyzed' state.
+* NOTE: On first startup of Anchore, the policy-engine performs a CVE data sync which may take several minutes to complete.
+During this time the system status will report 'partially_down' and any images added for analysis will stay in the 'not_analyzed' state.
 Once the sync is complete, any queued images will be analyzed and the system status will change to 'all_up'.
 
 Initial setup time can be >120sec for postgresql setup and readiness checks to pass for the services as indicated by pod state. You can check with:
     kubectl get pods -l app={{ template "anchore-engine.fullname" .}},component=api
+
+{{ if and .Release.IsUpgrade (regexMatch "1.22.[0-9]+" .Chart.Version) }}
+{{- $apiDeployment := (lookup "apps/v1" "Deployment" .Release.Namespace (include "anchore-engine.api.fullname" .)) }}
+{{- if not $apiDeployment }}
+**WARNING**
+Anchore Enterprise v4.4.x only supports upgrades from Enterprise v4.2.0 and higher.
+See release notes for more information - https://docs.anchore.com/current/docs/releasenotes/440/
+{{- end }}
+{{- end }}
+
+{{ if not .Values.anchoreEnterpriseGlobal.enabled }}
+**WARNING**
+As of January 2023, Anchore Engine is no longer maintained.
+There will be no future versions released. Users are advised to use Syft and Grype.
+{{- end }}


### PR DESCRIPTION
Tested with the following:
* Confirmed that upgrades from Enterprise v4.1.0 showed the warning about upgrade support during dry-run upgrades & failed during non dry-runs
```
helm install anchore anchore/anchore-engine --version 1.18.0 --set anchoreEnterpriseGlobal.enabled=true
helm upgrade anchore . --set anchoreEnterpriseGlobal.enabled=true --dry-run
helm upgrade anchore . --set anchoreEnterpriseGlobal.enabled=true 
```
* Confirmed that upgrading from Enterprise v4.2.0 was successful
```
 helm install anchore anchore/anchore-engine --set anchoreEnterpriseGlobal.enabled=true --version 1.20.0
 helm upgrade anchore . --set anchoreEnterpriseGlobal.enabled=true 
```
