### PR TITLE
[anchore-admission-controller] annotations for the validating webhook configuration

### DIFF
--- a/stable/anchore-admission-controller/ci/fake-values.yaml
+++ b/stable/anchore-admission-controller/ci/fake-values.yaml
@@ -1,3 +1,9 @@
+---
+apiService:
+  webhook:
+    annotations:
+      cert-manager.io/inject-ca-from: anchore/webhook-certificate
+      kustomize.toolkit.fluxcd.io/ssa: merge
 credentials:
   users:
   - username: user1

--- a/stable/anchore-admission-controller/templates/webhook.yaml
+++ b/stable/anchore-admission-controller/templates/webhook.yaml
@@ -4,6 +4,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ template "anchore-admission-controller.name" . }}-admission.anchore.io
   labels: {{- include "anchore-admission-controller.labels" . | nindent 4 }}
+  {{- with .Values.apiService.webhook.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 webhooks:
 - name: {{ template "anchore-admission-controller.name" . }}-admission.anchore.io
   clientConfig:

--- a/stable/anchore-admission-controller/values.yaml
+++ b/stable/anchore-admission-controller/values.yaml
@@ -48,6 +48,7 @@ apiService:
       - key: exclude.admission.anchore.io
         operator: NotIn
         values: ["true"]
+  annotations: {}
 
 anchoreEndpoint: ""
 policySelectors:


### PR DESCRIPTION
Add configurable annotations for the validating webhook configuration.
This can be used for instance to tell cert-manager to inject a CA cert instead of passing it in the values file.