### PR TITLE
fix certifi cacert issues when users are supplying custom certificates

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.23.0
+version: 1.23.1
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -430,7 +430,9 @@ Allows sourcing of a specified file in the entrypoint of all containers when .Va
 */}}
 {{- define "doSourceFile" }}
 {{- if .Values.anchoreGlobal.doSourceAtEntry.enabled }}
-    {{- printf "source %v;" .Values.anchoreGlobal.doSourceAtEntry.filePath }}
+    {{- with .Values.anchoreGlobal.doSourceAtEntry.filePath }}
+        {{- printf "if [ -f /home/anchore/venv/bin/activate ]; then source /home/anchore/venv/bin/activate; fi; if [ -f %v ]; then source %v; fi;" . . }}
+    {{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Added venv activation to `anchoreGlobal.doSourceAtEntry.enabled=true`. This will cause the certify cacert to be copied properly when the docker-entrypoint is run. Provides a temporary solution for users running into TLS issues on Anchore Enterprise v4.5.0 when providing custom certificates with `anchoreGlobal.certStoreSecretName`