### PR TITLE
Add Container securityContext

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.24.0
+version: 1.25.0
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.25.0
+version: 1.24.1
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/analyzer_deployment.yaml
+++ b/stable/anchore-engine/templates/analyzer_deployment.yaml
@@ -89,6 +89,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -112,6 +116,10 @@ spec:
         {{- else }}
         image: {{ .Values.anchoreGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
         {{- end }}
         command: ["/bin/sh", "-c"]
         {{- if .Values.anchoreEnterpriseGlobal.enabled }}

--- a/stable/anchore-engine/templates/api_deployment.yaml
+++ b/stable/anchore-engine/templates/api_deployment.yaml
@@ -77,6 +77,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -100,6 +104,10 @@ spec:
         {{- else }}
         image: {{ .Values.anchoreGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
         {{- end }}
         command: ["/bin/sh", "-c"]
         {{- if .Values.anchoreEnterpriseGlobal.enabled }}
@@ -203,6 +211,10 @@ spec:
       - name: {{ .Chart.Name }}-rbac-authorizer
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args: 
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade rbac_authorizer
@@ -284,6 +296,10 @@ spec:
       - name: "{{ .Chart.Name }}-reports-api"
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args: 
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade reports

--- a/stable/anchore-engine/templates/catalog_deployment.yaml
+++ b/stable/anchore-engine/templates/catalog_deployment.yaml
@@ -91,6 +91,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -114,6 +118,10 @@ spec:
         {{- else }}
         image: {{ .Values.anchoreGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
         {{- end }}
         command: ["/bin/sh", "-c"]
         {{- if .Values.anchoreEnterpriseGlobal.enabled }}

--- a/stable/anchore-engine/templates/engine_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/engine_upgrade_job.yaml
@@ -52,6 +52,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -91,9 +95,17 @@ spec:
         {{- if .Values.cloudsql.enabled }}
           - sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;
         securityContext:
+          {{- with .Values.anchoreGlobal.containerSecurityContext }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           capabilities:
             add:
               - SYS_PTRACE
+        {{- else }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- end }}
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}

--- a/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_deployment.yaml
@@ -82,6 +82,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -101,6 +105,10 @@ spec:
       - name: "{{ .Chart.Name }}-{{ $component }}"
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade feeds

--- a/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_upgrade_job.yaml
@@ -45,6 +45,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -79,9 +83,17 @@ spec:
         {{- if .Values.cloudsql.enabled }}
           -  sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;
         securityContext:
+          {{- with .Values.anchoreGlobal.containerSecurityContext }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           capabilities:
             add:
               - SYS_PTRACE
+        {{- else }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- end }}
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}

--- a/stable/anchore-engine/templates/enterprise_notifications_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_notifications_deployment.yaml
@@ -68,6 +68,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -87,6 +91,10 @@ spec:
       - name: "{{ .Chart.Name }}-{{ $component }}"
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade notifications
@@ -168,6 +176,10 @@ spec:
       - name: {{ .Chart.Name }}-rbac-authorizer
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade rbac_authorizer

--- a/stable/anchore-engine/templates/enterprise_rbac_manager_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_rbac_manager_deployment.yaml
@@ -68,6 +68,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -87,6 +91,10 @@ spec:
       - name: "{{ .Chart.Name }}-{{ $component }}"
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade rbac_manager
@@ -167,6 +175,10 @@ spec:
       - name: {{ .Chart.Name }}-rbac-authorizer
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade rbac_authorizer

--- a/stable/anchore-engine/templates/enterprise_reports_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_reports_deployment.yaml
@@ -68,6 +68,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -87,6 +91,10 @@ spec:
       - name: "{{ .Chart.Name }}-{{ $component }}"
         image: {{ .Values.anchoreEnterpriseGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseGlobal.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh anchore-enterprise-manager service start --no-auto-upgrade reports_worker

--- a/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
+++ b/stable/anchore-engine/templates/enterprise_ui_deployment.yaml
@@ -72,6 +72,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -91,6 +95,10 @@ spec:
       - name: "{{ .Chart.Name }}-{{ $component }}"
         image: {{ .Values.anchoreEnterpriseUi.image }}
         imagePullPolicy: {{ .Values.anchoreEnterpriseUi.imagePullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ print (include "doSourceFile" .) }} /docker-entrypoint.sh node /home/node/aui/build/server.js

--- a/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
+++ b/stable/anchore-engine/templates/enterprise_upgrade_job.yaml
@@ -45,6 +45,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -79,9 +83,17 @@ spec:
         {{- if .Values.cloudsql.enabled }}
           - sql_proxy_pid=$(pgrep cloud_sql_proxy) && kill -INT $sql_proxy_pid;
         securityContext:
+          {{- with .Values.anchoreGlobal.containerSecurityContext }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           capabilities:
             add:
               - SYS_PTRACE
+        {{- else }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- end }}
         envFrom:
         {{- if not .Values.inject_secrets_via_env }}

--- a/stable/anchore-engine/templates/policy_engine_deployment.yaml
+++ b/stable/anchore-engine/templates/policy_engine_deployment.yaml
@@ -88,6 +88,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -111,6 +115,10 @@ spec:
         {{- else }}
         image: {{ .Values.anchoreGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
         {{- end }}
         command: ["/bin/sh", "-c"]
         {{- if .Values.anchoreEnterpriseGlobal.enabled }}

--- a/stable/anchore-engine/templates/simplequeue_deployment.yaml
+++ b/stable/anchore-engine/templates/simplequeue_deployment.yaml
@@ -74,6 +74,10 @@ spec:
       - name: cloudsql-proxy
         image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
         imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/cloud_sql_proxy"]
         args:
         {{- if .Values.cloudsql.extraArgs }}
@@ -97,6 +101,10 @@ spec:
         {{- else }}
         image: {{ .Values.anchoreGlobal.image }}
         imagePullPolicy: {{ .Values.anchoreGlobal.imagePullPolicy }}
+        {{- end }}
+        {{- with .Values.anchoreGlobal.containerSecurityContext }}
+        securityContext:
+          {{ toYaml . | nindent 10 }}
         {{- end }}
         command: ["/bin/sh", "-c"]
         {{- if .Values.anchoreEnterpriseGlobal.enabled }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -181,7 +181,7 @@ anchoreGlobal:
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
-  
+
   # Specify your container securityContext here
   containerSecurityContext: {}
 

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -181,6 +181,9 @@ anchoreGlobal:
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
+  
+  # Specify your container securityContext here
+  containerSecurityContext: {}
 
   ###
   # Start of General Anchore Configurations (populates /config/config.yaml)


### PR DESCRIPTION
Adds securityContext at the container level and a new value in `anchoreGlobal` to set this context. I have been maintaining this in my own environment and rebasing with every new chart release, but I'd like to get this upstream.

- I can't test the cloudsql proxy changes (I don't use cloudsql)
- I'm unsure in the upgrade jobs whether this is the best way to organize this change