### PR TITLE
Bump KAI to v0.5.0

### DIFF
--- a/stable/kai/Chart.yaml
+++ b/stable/kai/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kai
-version: 0.3.3
-appVersion: 0.3.2
+version: 0.5.0
+appVersion: 0.5.0
 description: A Helm chart for Kubernetes Automated Inventory, which describes which images are in use in a given Kubernetes Cluster
 keywords:
   - analysis

--- a/stable/kai/templates/configmap.yaml
+++ b/stable/kai/templates/configmap.yaml
@@ -40,3 +40,4 @@ data:
       http:
         insecure: {{ .Values.kai.anchore.http.insecure }}
         timeout-seconds: {{ .Values.kai.anchore.http.timeoutSeconds }}
+    verbose-inventory-reports: {{ .Values.kai.verboseInventoryReports }}

--- a/stable/kai/values.yaml
+++ b/stable/kai/values.yaml
@@ -164,3 +164,5 @@ kai:
     http:
       insecure: true
       timeoutSeconds: 10
+
+  verboseInventoryReports: false

--- a/stable/kai/values.yaml
+++ b/stable/kai/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: anchore/kai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.3.2"
+  tag: "v0.5.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
- chore: add verboseInventoryReports option to KAI helm chart
- feat: bump KAI to v0.5.0
