### PR TITLE
Add quotes to db config environment vars

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.24.1
+version: 1.24.2
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/engine_configmap.yaml
+++ b/stable/anchore-engine/templates/engine_configmap.yaml
@@ -100,11 +100,11 @@ data:
     credentials:
       database:
       {{- if .Values.anchoreEnterpriseGlobal.enabled }}
-        user: ${ANCHORE_DB_USER}
-        password: ${ANCHORE_DB_PASSWORD}
-        host: ${ANCHORE_DB_HOST}
-        port: ${ANCHORE_DB_PORT}
-        name: ${ANCHORE_DB_NAME}
+        user: "${ANCHORE_DB_USER}"
+        password: "${ANCHORE_DB_PASSWORD}"
+        host: "${ANCHORE_DB_HOST}"
+        port: "${ANCHORE_DB_PORT}"
+        name: "${ANCHORE_DB_NAME}"
       {{- else }}
         db_connect: "postgresql://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_HOST}:${ANCHORE_DB_PORT}/${ANCHORE_DB_NAME}"
       {{- end }}

--- a/stable/anchore-engine/templates/enterprise_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_configmap.yaml
@@ -69,11 +69,11 @@ data:
 
     credentials:
       database:
-        user: ${ANCHORE_DB_USER}
-        password: ${ANCHORE_DB_PASSWORD}
-        host: ${ANCHORE_DB_HOST}
-        port: ${ANCHORE_DB_PORT}
-        name: ${ANCHORE_DB_NAME}
+        user: "${ANCHORE_DB_USER}"
+        password: "${ANCHORE_DB_PASSWORD}"
+        host: "${ANCHORE_DB_HOST}"
+        port: "${ANCHORE_DB_PORT}"
+        name: "${ANCHORE_DB_NAME}"
 
         db_connect_args:
           timeout: {{ .Values.anchoreGlobal.dbConfig.timeout }}

--- a/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
+++ b/stable/anchore-engine/templates/enterprise_feeds_configmap.yaml
@@ -78,11 +78,11 @@ data:
 
     credentials:
       database:
-        user: ${ANCHORE_FEEDS_DB_USER}
-        password: ${ANCHORE_FEEDS_DB_PASSWORD}
-        host: ${ANCHORE_FEEDS_DB_HOST}
-        port: ${ANCHORE_FEEDS_DB_PORT}
-        name: ${ANCHORE_FEEDS_DB_NAME}
+        user: "${ANCHORE_FEEDS_DB_USER}"
+        password: "${ANCHORE_FEEDS_DB_PASSWORD}"
+        host: "${ANCHORE_FEEDS_DB_HOST}"
+        port: "${ANCHORE_FEEDS_DB_PORT}"
+        name: "${ANCHORE_FEEDS_DB_NAME}"
 
         db_connect_args:
           timeout: {{ .Values.anchoreEnterpriseFeeds.dbConfig.timeout }}


### PR DESCRIPTION
To prevent '!' from being interpreted by YAML we need to quote out all env vars used for db config variables.