### PR TITLE
feat: updates mountPath for RedHat sourced Postgres image when using OpenShift

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.26.4
+version: 1.26.5
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -127,7 +127,7 @@ postgresql:
   - name: POSTGRESQL_USER
     value: anchoreengine
   - name: POSTGRESQL_PASSWORD
-    value: anchore-postgres,123
+    value: <PGPASSWORD>
   - name: POSTGRESQL_DATABASE
     value: anchore
   - name: PGUSER
@@ -136,7 +136,7 @@ postgresql:
     value: /opt/rh/rh-postgresql96/root/usr/lib64
   - name: PATH
      value: /opt/rh/rh-postgresql96/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    postgresPassword: <PASSWORD>
+    postgresPassword: <PGPASSWORD>
     persistence:
       size: 20Gi
 
@@ -145,6 +145,10 @@ anchoreGlobal:
   defaultAdminEmail: <EMAIL>
   enableMetrics: True
   openShiftDeployment: True
+  securityContext:
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
 
 anchore-feeds-db:
   image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
@@ -153,7 +157,7 @@ anchore-feeds-db:
   - name: POSTGRESQL_USER
     value: anchoreengine
   - name: POSTGRESQL_PASSWORD
-    value: anchore-postgres,123
+    value: <PGPASSWORD>
   - name: POSTGRESQL_DATABASE
     value: anchore
   - name: PGUSER
@@ -162,13 +166,26 @@ anchore-feeds-db:
     value: /opt/rh/rh-postgresql96/root/usr/lib64
   - name: PATH
      value: /opt/rh/rh-postgresql96/root/usr/bin:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    postgresPassword: <PASSWORD>
+    postgresPassword: <PGPASSWORD>
     persistence:
       size: 50Gi
 
 ui-redis:
   auth:
     password: <PASSWORD>
+  master:
+    podSecurityContext:
+      enabled: true
+      fsGroup: 1000670000
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1000670000
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
 ```
 
 # Chart Updates

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -19,9 +19,15 @@ postgresql:
   persistence:
     resourcePolicy: keep
     size: 20Gi
+    # If running on OpenShift using the RedHat images for PostgreSQL, uncomment this line to ensure the PVC is mounted properly
+    # mountPath: /var/lib/pgsql/data
 
   # If running on OpenShift - uncomment the image, imageTag & extraEnv values below.
+  # For upgrades from previous deployments on PG9.6, use this
   # image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+
+  # For new installs, please use PG v13 instead of 9.6
+  # image: registry.redhat.io/rhel9/postgresql-13
   # imageTag: latest
   # extraEnv:
   # - name: POSTGRESQL_USER

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -786,9 +786,15 @@ anchore-feeds-db:
   persistence:
     resourcePolicy: keep
     size: 20Gi
+    # If running on OpenShift using the RedHat images for PostgreSQL, uncomment this line to ensure the PVC is mounted properly
+    # mountPath: /var/lib/pgsql/data
 
   # If running on OpenShift - uncomment the image, imageTag & extraEnv values below.
+  # For upgrades from previous deployments on PG9.6, use this
   # image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+
+  # For new installs, please use PG v13 instead of 9.6
+  # image: registry.redhat.io/rhel9/postgresql-13
   # imageTag: latest
   # extraEnv:
   # - name: POSTGRESQL_USER


### PR DESCRIPTION
The RedHat postgres images use a different data path and ignore PGDATA environment vars, so the mount path must be updated in order to ensure the DB PVC is used correctly for data.

Without this update, the DB will work, but DB data is lost when the pod is deleted.