### PR TITLE
updating enterprise oauth keys and config

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "2.1.2"
+version: "2.2.0"
 appVersion: "5.1.0"
 kubeVersion: 1.23.x - 1.28.x || 1.23.x-x - 1.28.x-x
 description: |

--- a/stable/enterprise/README.md
+++ b/stable/enterprise/README.md
@@ -992,9 +992,9 @@ This rollback procedure is designed to revert your environment to its pre-migrat
 | `anchoreConfig.user_authentication.oauth.enabled`                              | Enable OAuth for Anchore user authentication                                                                                     | `true`             |
 | `anchoreConfig.user_authentication.oauth.default_token_expiration_seconds`     | The expiration, in seconds, for OAuth tokens                                                                                     | `3600`             |
 | `anchoreConfig.user_authentication.oauth.refresh_token_expiration_seconds`     | The expiration, in seconds, for OAuth refresh tokens                                                                             | `86400`            |
-| `anchoreConfig.user_authentication.oauth.allow_api_keys_for_saml_users`        | Enable API key generation and authentication for SAML users                                                                      | `false`            |
-| `anchoreConfig.user_authentication.oauth.max_api_key_age_days`                 | The maximum age, in days, for API keys                                                                                           | `365`              |
-| `anchoreConfig.user_authentication.oauth.max_api_keys_per_user`                | The maximum number of API keys per user                                                                                          | `100`              |
+| `anchoreConfig.user_authentication.allow_api_keys_for_saml_users`        | Enable API key generation and authentication for SAML users                                                                      | `false`            |
+| `anchoreConfig.user_authentication.max_api_key_age_days`                 | The maximum age, in days, for API keys                                                                                           | `365`              |
+| `anchoreConfig.user_authentication.max_api_keys_per_user`                | The maximum number of API keys per user                                                                                          | `100`              |
 | `anchoreConfig.user_authentication.hashed_passwords`                           | Enable storing passwords as secure hashes in the database                                                                        | `true`             |
 | `anchoreConfig.user_authentication.sso_require_existing_users`                 | set to true in order to disable the SSO JIT provisioning during authentication                                                   | `false`            |
 | `anchoreConfig.metrics.enabled`                                                | Enable Prometheus metrics for all Anchore services                                                                               | `false`            |
@@ -1349,6 +1349,13 @@ For the latest updates and features in Anchore Enterprise, see the official [Rel
 - **Major Chart Version Change (e.g., v0.1.2 -> v1.0.0)**: Signifies an incompatible breaking change that necessitates manual intervention, such as updates to your values file or data migrations.
 - **Minor Chart Version Change (e.g., v0.1.2 -> v0.2.0)**: Indicates a significant change to the deployment that does not require manual intervention.
 - **Patch Chart Version Change (e.g., v0.1.2 -> v0.1.3)**: Indicates a backwards-compatible bug fix or documentation update.
+
+### V2.2.0
+
+- The following keys were changed:
+    1. anchoreConfig.user_authentication.oauth.allow_api_keys_for_saml_users -> anchoreConfig.user_authentication.allow_api_keys_for_saml_users
+    2. anchoreConfig.user_authentication.oauth.max_api_key_age_days -> anchoreConfig.user_authentication.max_api_key_age_days
+    3. anchoreConfig.user_authentication.oauth.max_api_keys_per_user -> anchoreConfig.user_authentication.max_api_keys_per_user
 
 ### V2.1.0
 

--- a/stable/enterprise/files/default_config.yaml
+++ b/stable/enterprise/files/default_config.yaml
@@ -40,9 +40,9 @@ user_authentication:
     enabled: ${ANCHORE_OAUTH_ENABLED}
     default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}
     refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}
-    allow_api_keys_for_saml_users: {{ .Values.anchoreConfig.user_authentication.oauth.allow_api_keys_for_saml_users }}
-    max_api_key_age_days: {{ .Values.anchoreConfig.user_authentication.oauth.max_api_key_age_days }}
-    max_api_keys_per_user: {{ .Values.anchoreConfig.user_authentication.oauth.max_api_keys_per_user }}
+  allow_api_keys_for_saml_users: {{ .Values.anchoreConfig.user_authentication.allow_api_keys_for_saml_users }}
+  max_api_key_age_days: {{ .Values.anchoreConfig.user_authentication.max_api_key_age_days }}
+  max_api_keys_per_user: {{ .Values.anchoreConfig.user_authentication.max_api_keys_per_user }}
 
 credentials:
   database:

--- a/stable/enterprise/tests/__snapshot__/configmap_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/configmap_test.yaml.snap
@@ -87,9 +87,9 @@ should render the configmaps:
             enabled: ${ANCHORE_OAUTH_ENABLED}
             default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}
             refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}
-            allow_api_keys_for_saml_users: false
-            max_api_key_age_days: 365
-            max_api_keys_per_user: 100
+          allow_api_keys_for_saml_users: false
+          max_api_key_age_days: 365
+          max_api_keys_per_user: 100
 
         credentials:
           database:

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -233,10 +233,10 @@ anchoreConfig:
   ## @param anchoreConfig.user_authentication.oauth.enabled Enable OAuth for Anchore user authentication
   ## @param anchoreConfig.user_authentication.oauth.default_token_expiration_seconds The expiration, in seconds, for OAuth tokens
   ## @param anchoreConfig.user_authentication.oauth.refresh_token_expiration_seconds The expiration, in seconds, for OAuth refresh tokens
-  ## @param anchoreConfig.user_authentication.oauth.allow_api_keys_for_saml_users Enable API key generation and authentication for SAML users
+  ## @param anchoreConfig.user_authentication.allow_api_keys_for_saml_users Enable API key generation and authentication for SAML users
   ## NOTE: Enterprise cannot automatically revoke or delete keys for disabled SAML users, the admin must revoke all keys assigned to a SAML user after disabling that user.
-  ## @param anchoreConfig.user_authentication.oauth.max_api_key_age_days The maximum age, in days, for API keys
-  ## @param anchoreConfig.user_authentication.oauth.max_api_keys_per_user The maximum number of API keys per user
+  ## @param anchoreConfig.user_authentication.max_api_key_age_days The maximum age, in days, for API keys
+  ## @param anchoreConfig.user_authentication.max_api_keys_per_user The maximum number of API keys per user
   ## ref: https://docs.anchore.com/current/docs/installation/configuration/user_credential_storage/#bearer-tokensoauth2
   ##
   ## @param anchoreConfig.user_authentication.hashed_passwords Enable storing passwords as secure hashes in the database
@@ -252,9 +252,9 @@ anchoreConfig:
       enabled: true
       default_token_expiration_seconds: 3600
       refresh_token_expiration_seconds: 86400
-      allow_api_keys_for_saml_users: false
-      max_api_key_age_days: 365
-      max_api_keys_per_user: 100
+    allow_api_keys_for_saml_users: false
+    max_api_key_age_days: 365
+    max_api_keys_per_user: 100
     hashed_passwords: true
     sso_require_existing_users: false
 


### PR DESCRIPTION
- The following keys were changed due to indentation error:
- - anchoreConfig.user_authentication.oauth.allow_api_keys_for_saml_users -> anchoreConfig.user_authentication.allow_api_keys_for_saml_users
- - anchoreConfig.user_authentication.oauth.max_api_key_age_days -> anchoreConfig.user_authentication.max_api_key_age_days
- - anchoreConfig.user_authentication.oauth.max_api_keys_per_user -> anchoreConfig.user_authentication.max_api_keys_per_user