### PR TITLE
making kubectl scale down preupgrade container configurable

### DIFF
--- a/stable/feeds/Chart.yaml
+++ b/stable/feeds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: feeds
 type: application
-version: "2.1.0"
+version: "2.1.1"
 appVersion: "5.1.0"
 kubeVersion: 1.23.x - 1.27.x || 1.23.x-x - 1.28.x-x
 description: Anchore feeds service

--- a/stable/feeds/README.md
+++ b/stable/feeds/README.md
@@ -434,20 +434,21 @@ anchoreConfig:
 
 ### Anchore Feeds Upgrade Job Parameters
 
-| Name                                      | Description                                                                                                                                     | Value   |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `feedsUpgradeJob.enabled`                 | Enable the Anchore Feeds database upgrade job                                                                                                   | `true`  |
-| `feedsUpgradeJob.force`                   | Force the Anchore Feeds database upgrade job to run as a regular job instead of as a Helm hook                                                  | `false` |
-| `feedsUpgradeJob.rbacCreate`              | Create RBAC resources for the upgrade job                                                                                                       | `true`  |
-| `feedsUpgradeJob.serviceAccountName`      | Use an existing service account for the upgrade job                                                                                             | `""`    |
-| `feedsUpgradeJob.usePostUpgradeHook`      | Use a Helm post-upgrade hook to run the upgrade job instead of the default pre-upgrade hook. This job does not require creating RBAC resources. | `false` |
-| `feedsUpgradeJob.nodeSelector`            | Node labels for the Anchore Feeds upgrade job pod assignment                                                                                    | `{}`    |
-| `feedsUpgradeJob.tolerations`             | Tolerations for the Anchore Feeds upgrade job pod assignment                                                                                    | `[]`    |
-| `feedsUpgradeJob.affinity`                | Affinity for the Anchore Feeds upgrade job pod assignment                                                                                       | `{}`    |
-| `feedsUpgradeJob.annotations`             | Annotations for the Anchore Feeds upgrade job                                                                                                   | `{}`    |
-| `feedsUpgradeJob.labels`                  | Labels for the Anchore Feeds upgrade job                                                                                                        | `{}`    |
-| `feedsUpgradeJob.resources`               | Resources for the Anchore Feeds upgrade job                                                                                                     | `{}`    |
-| `feedsUpgradeJob.ttlSecondsAfterFinished` | The time period in seconds the upgrade job, and it's related pods should be retained for                                                        | `-1`    |
+| Name                                      | Description                                                                                                                                     | Value                  |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `feedsUpgradeJob.enabled`                 | Enable the Anchore Feeds database upgrade job                                                                                                   | `true`                 |
+| `feedsUpgradeJob.force`                   | Force the Anchore Feeds database upgrade job to run as a regular job instead of as a Helm hook                                                  | `false`                |
+| `feedsUpgradeJob.rbacCreate`              | Create RBAC resources for the upgrade job                                                                                                       | `true`                 |
+| `feedsUpgradeJob.serviceAccountName`      | Use an existing service account for the upgrade job                                                                                             | `""`                   |
+| `feedsUpgradeJob.usePostUpgradeHook`      | Use a Helm post-upgrade hook to run the upgrade job instead of the default pre-upgrade hook. This job does not require creating RBAC resources. | `false`                |
+| `feedsUpgradeJob.kubectlImage`            | The image to use for the upgrade job's init container that uses kubectl to scale down deployments before an upgrade                             | `bitnami/kubectl:1.27` |
+| `feedsUpgradeJob.nodeSelector`            | Node labels for the Anchore Feeds upgrade job pod assignment                                                                                    | `{}`                   |
+| `feedsUpgradeJob.tolerations`             | Tolerations for the Anchore Feeds upgrade job pod assignment                                                                                    | `[]`                   |
+| `feedsUpgradeJob.affinity`                | Affinity for the Anchore Feeds upgrade job pod assignment                                                                                       | `{}`                   |
+| `feedsUpgradeJob.annotations`             | Annotations for the Anchore Feeds upgrade job                                                                                                   | `{}`                   |
+| `feedsUpgradeJob.labels`                  | Labels for the Anchore Feeds upgrade job                                                                                                        | `{}`                   |
+| `feedsUpgradeJob.resources`               | Resources for the Anchore Feeds upgrade job                                                                                                     | `{}`                   |
+| `feedsUpgradeJob.ttlSecondsAfterFinished` | The time period in seconds the upgrade job, and it's related pods should be retained for                                                        | `-1`                   |
 
 ### Ingress Parameters
 

--- a/stable/feeds/templates/hooks/pre-upgrade/upgrade_job.yaml
+++ b/stable/feeds/templates/hooks/pre-upgrade/upgrade_job.yaml
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       initContainers:
         - name: scale-down-anchore
-          image: bitnami/kubectl:1.27
+          image: {{ .Values.feedsUpgradeJob.kubectlImage }}
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/stable/feeds/values.yaml
+++ b/stable/feeds/values.yaml
@@ -486,7 +486,7 @@ feedsUpgradeJob:
   usePostUpgradeHook: false
 
 
-  ## @param feedsUpgradeJob.kubectlImage the image to use for the upgrade job's init container that uses kubectl to scale down deployments before an upgrade
+  ## @param feedsUpgradeJob.kubectlImage The image to use for the upgrade job's init container that uses kubectl to scale down deployments before an upgrade
   ## This is only used in the preupgrade job.
   ##
   kubectlImage: bitnami/kubectl:1.27

--- a/stable/feeds/values.yaml
+++ b/stable/feeds/values.yaml
@@ -485,6 +485,12 @@ feedsUpgradeJob:
   ##
   usePostUpgradeHook: false
 
+
+  ## @param feedsUpgradeJob.kubectlImage the image to use for the upgrade job's init container that uses kubectl to scale down deployments before an upgrade
+  ## This is only used in the preupgrade job.
+  ##
+  kubectlImage: bitnami/kubectl:1.27
+
   ## @param feedsUpgradeJob.nodeSelector Node labels for the Anchore Feeds upgrade job pod assignment
   ##
   nodeSelector: {}


### PR DESCRIPTION
Allow for changing the initContainers image in the preupgrade job that does kubectl scale down