### PR TITLE
feat: bump k8s-inventory version

### DIFF
--- a/stable/k8s-inventory/Chart.yaml
+++ b/stable/k8s-inventory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8s-inventory
-version: 0.1.0
-appVersion: "1.1.1"
+version: 0.2.0
+appVersion: "1.2.0"
 description: A Helm chart for Kubernetes Automated Inventory, which describes which images are in use in a given Kubernetes Cluster
 keywords:
   - analysis

--- a/stable/k8s-inventory/templates/deployment.yaml
+++ b/stable/k8s-inventory/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["anchore-k8s-inventory"]
+          command: ["/anchore-k8s-inventory"]
           ports:
             - name: http
               containerPort: 80
@@ -53,7 +53,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - anchore-k8s-inventory
+                - /anchore-k8s-inventory
                 - version
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -63,7 +63,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                - anchore-k8s-inventory
+                - /anchore-k8s-inventory
                 - version
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}

--- a/stable/k8s-inventory/values.yaml
+++ b/stable/k8s-inventory/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 image:
   pullPolicy: "IfNotPresent"
   repository: "anchore/k8s-inventory"
-  tag: "v1.1.1"
+  tag: "v1.2.0"
 
 ## @param imagePullSecrets secrets where Kubernetes should get the credentials for pulling private images
 ##


### PR DESCRIPTION
Changes the entrypoint of the container to /anchore-k8s-inventory as it
is now based on a scratch container and should not assume the binary is
present in the PATH.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
