### PR TITLE
Add component values to feeds upgrade job

### DIFF
--- a/stable/feeds/Chart.yaml
+++ b/stable/feeds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: feeds
 type: application
-version: "2.2.2"
+version: "2.2.3"
 appVersion: "5.2.0"
 kubeVersion: 1.23.x - 1.27.x || 1.23.x-x - 1.28.x-x
 description: Anchore feeds service

--- a/stable/feeds/templates/hooks/post-upgrade/upgrade_job.yaml
+++ b/stable/feeds/templates/hooks/post-upgrade/upgrade_job.yaml
@@ -1,12 +1,13 @@
 {{- if and .Values.feedsUpgradeJob.enabled .Values.feedsUpgradeJob.usePostUpgradeHook -}}
+{{- $component := "upgradeJob" -}}
 
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "feeds.upgradeJob.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "feeds.common.labels" . | nindent 4 }}
-  annotations: {{- include "feeds.common.annotations" (merge (dict "nil" true) .) | nindent 4 }}
+  labels: {{- include "feeds.common.labels" (merge (dict "component" $component) .) | nindent 4 }}
+  annotations: {{- include "feeds.common.annotations" (merge (dict "component" $component "nil" true) .) | nindent 4 }}
   {{- if not .Values.feedsUpgradeJob.force }}
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "0"
@@ -15,8 +16,8 @@ spec:
   template:
     metadata:
       name: {{ template "feeds.upgradeJob.fullname" . }}
-      labels: {{- include "feeds.common.labels" . | nindent 8 }}
-      annotations: {{- include "feeds.common.annotations" . | nindent 8 }}
+      labels: {{- include "feeds.common.labels" (merge (dict "component" $component) .) | nindent 8 }}
+      annotations: {{- include "feeds.common.annotations" (merge (dict "component" $component "nil" true) .) | nindent 8 }}
     spec:
     {{- with .Values.securityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
@@ -100,7 +101,7 @@ spec:
                 name: {{ template "feeds.fullname" . }}
           {{- end }}
         {{- end }}
-          env: {{- include "feeds.common.environment" . | nindent 12 }}
+          env: {{- include "feeds.common.environment" (merge (dict "component" $component) .) | nindent 12 }}
           volumeMounts:
           {{- if (.Values.certStoreSecretName) }}
             - name: certs

--- a/stable/feeds/templates/hooks/pre-upgrade/upgrade_job.yaml
+++ b/stable/feeds/templates/hooks/pre-upgrade/upgrade_job.yaml
@@ -1,12 +1,13 @@
 {{- if and .Values.feedsUpgradeJob.enabled (not .Values.feedsUpgradeJob.usePostUpgradeHook) -}}
+{{- $component := "upgradeJob" -}}
 
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "feeds.upgradeJob.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "feeds.common.labels" . | nindent 4 }}
-  annotations: {{- include "feeds.common.annotations" (merge (dict "nil" true) .) | nindent 4 }}
+  labels: {{- include "feeds.common.labels" (merge (dict "component" $component) .) | nindent 4 }}
+  annotations: {{- include "feeds.common.annotations" (merge (dict "component" $component "nil" true) .) | nindent 4 }}
   {{- if not .Values.feedsUpgradeJob.force }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "3"
@@ -19,8 +20,8 @@ spec:
   template:
     metadata:
       name: {{ template "feeds.upgradeJob.fullname" . }}
-      labels: {{- include "feeds.common.labels" . | nindent 8 }}
-      annotations: {{- include "feeds.common.annotations" . | nindent 8 }}
+      labels: {{- include "feeds.common.labels" (merge (dict "component" $component "nil" true) .) | nindent 8 }}
+      annotations: {{- include "feeds.common.annotations" (merge (dict "component" $component "nil" true) .) | nindent 8 }}
     spec:
     {{- with .Values.securityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
@@ -81,7 +82,7 @@ spec:
         - name: wait-for-db
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          env: {{- include "feeds.common.environment" . | nindent 12 }}
+          env: {{- include "feeds.common.environment" (merge (dict "component" $component) .) | nindent 12 }}
           command: ["/bin/bash", "-c"]
           args:
             - |
@@ -133,7 +134,7 @@ spec:
                 name: {{ template "feeds.fullname" . }}
           {{- end }}
         {{- end }}
-          env: {{- include "feeds.common.environment" . | nindent 12 }}
+          env: {{- include "feeds.common.environment" (merge (dict "component" $component) .) | nindent 12 }}
           volumeMounts:
           {{- if .Values.certStoreSecretName }}
             - name: certs


### PR DESCRIPTION
The feeds upgrade job did not seem to honor feedsUpgradeJob.labels

Copied the pattern from the enterprise chart
- added a component name
- added the component merge to calls to enterprise.common.*

In my particular use case, I needed to disable a sidecar by adding a label to the upgrade job.