### PR TITLE
Common nodeSelector, affinity, tolerations

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "2.5.0"
+version: "2.5.1"
 appVersion: "5.4.0"
 kubeVersion: 1.23.x - 1.28.x || 1.23.x-x - 1.29.x-x
 description: |

--- a/stable/enterprise/templates/_common.tpl
+++ b/stable/enterprise/templates/_common.tpl
@@ -231,13 +231,13 @@ serviceAccountName: {{ include "enterprise.serviceAccountName" (merge (dict "com
 imagePullSecrets:
   - name: {{ . }}
 {{- end }}
-{{- with (index .Values (print $component)).nodeSelector }}
+{{- with (default .Values.nodeSelector (index .Values (print $component)).nodeSelector) }}
 nodeSelector: {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with (index .Values (print $component)).affinity }}
+{{- with (default .Values.affinity (index .Values (print $component)).affinity) }}
 affinity: {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with (index .Values (print $component)).tolerations }}
+{{- with (default .Values.tolerations (index .Values (print $component)).tolerations) }}
 tolerations: {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -100,6 +100,18 @@ labels: {}
 ##
 annotations: {}
 
+## @param nodeSelector Common nodeSelector set on all Kubernetes pods
+##
+nodeSelector: {}
+
+## @param tolerations Common tolerations set on all Kubernetes pods
+##
+tolerations: []
+
+## @param affinity Common affinity set on all Kubernetes pods
+##
+affinity: {}
+
 ## @param scratchVolume.mountPath The mount path of an external volume for scratch space. Used for the following pods: analyzer, policy-engine, catalog, and reports
 ## @param scratchVolume.fixGroupPermissions Enable an initContainer that will fix the fsGroup permissions on all scratch volumes
 ## @param scratchVolume.fixerInitContainerImage The image to use for the mode-fixer initContainer

--- a/stable/feeds/Chart.yaml
+++ b/stable/feeds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: feeds
 type: application
-version: "2.4.0"
+version: "2.4.1"
 appVersion: "5.4.0"
 kubeVersion: 1.23.x - 1.27.x || 1.23.x-x - 1.29.x-x
 description: Anchore feeds service

--- a/stable/feeds/templates/hooks/pre-upgrade/upgrade_job.yaml
+++ b/stable/feeds/templates/hooks/pre-upgrade/upgrade_job.yaml
@@ -37,13 +37,13 @@ spec:
         - name: {{ . }}
     {{- end }}
       restartPolicy: Never
-    {{- with .Values.feedsUpgradeJob.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.feedsUpgradeJob.nodeSelector) }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.feedsUpgradeJob.affinity }}
+    {{- with (default .Values.affinity .Values.feedsUpgradeJob.affinity) }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.feedsUpgradeJob.tolerations }}
+    {{- with (default .Values.tolerations .Values.feedsUpgradeJob.tolerations) }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if or .Values.certStoreSecretName .Values.cloudsql.useExistingServiceAcc .Values.extraVolumes }}


### PR DESCRIPTION
I'd like to add common nodeSelector, affinity, and tolerations to both charts to make values files more DRY.

In my case (and I suspect others), I use the same nodeSelector and tolerations for every service. The intent of this PR is (for both feeds and enterprise charts), to allow setting of those values at the root of the values files for each chart. The changes:

- Use the $components nodeSelector/affinity/tolerations if set
- If not set at $component level, use the common setting

This way I can set these values one time in each chart and not have to maintain it all over my values files (such as in the case of new deployments being created)