### PR TITLE
stable/enterprise: fix extraVolumes in UI deployment

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "2.5.2"
+version: "2.5.3"
 appVersion: "5.4.0"
 kubeVersion: 1.23.x - 1.28.x || 1.23.x-x - 1.29.x-x
 description: |

--- a/stable/enterprise/templates/ui_deployment.yaml
+++ b/stable/enterprise/templates/ui_deployment.yaml
@@ -40,9 +40,6 @@ spec:
           secret:
             secretName: {{ .Values.cloudsql.serviceAccSecretName }}
       {{- end }}
-      {{- with .Values.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
         {{- include "enterprise.common.cloudsqlContainer" . | nindent 8 }}
@@ -91,9 +88,6 @@ spec:
             - name: certs
               mountPath: /home/anchore/certs/
               readOnly: true
-          {{- end }}
-          {{- with .Values.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
           {{- end }}
           livenessProbe:
             tcpSocket:


### PR DESCRIPTION
remove reference to the extraVolumes & extraVolumeMounts in ui deployment. This should rely solely on extraVolume helper template.

Fixes #364 