### PR TITLE
enterprise: bumping image version to v5.8.1

### DIFF
--- a/stable/enterprise/Chart.lock
+++ b/stable/enterprise/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 17.11.8
 - name: feeds
   repository: https://charts.anchore.io/stable
-  version: 2.8.0
-digest: sha256:e18505c97fed5b83f4165e48141da0a80e955fd31aeff6ab1e32ddb350d6d250
-generated: "2024-07-30T16:08:35.816554-04:00"
+  version: 2.8.1
+digest: sha256:579bc21169746a5ed09f3e8c03148a53553baf9a2d84513e851e2cddf29e0337
+generated: "2024-08-09T17:01:00.083497-04:00"

--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise
-version: "2.9.0"
-appVersion: "5.8.0"
+version: "2.9.1"
+appVersion: "5.8.1"
 kubeVersion: 1.23.x - 1.30.x || 1.23.x-x - 1.30.x-x
 description: |
   Anchore Enterprise is a complete container security workflow solution for professional teams. Easily integrating with CI/CD systems,

--- a/stable/enterprise/README.md
+++ b/stable/enterprise/README.md
@@ -1006,7 +1006,7 @@ To restore your deployment to using your previous driver configurations:
 
 | Name                                    | Description                                                                                                                        | Value                                 |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `image`                                 | Image used for all Anchore Enterprise deployments, excluding Anchore UI                                                            | `docker.io/anchore/enterprise:v5.8.0` |
+| `image`                                 | Image used for all Anchore Enterprise deployments, excluding Anchore UI                                                            | `docker.io/anchore/enterprise:v5.8.1` |
 | `imagePullPolicy`                       | Image pull policy used by all deployments                                                                                          | `IfNotPresent`                        |
 | `imagePullSecretName`                   | Name of Docker credentials secret for access to private repos                                                                      | `anchore-enterprise-pullcreds`        |
 | `startMigrationPod`                     | Spin up a Database migration pod to help migrate the database to the new schema                                                    | `false`                               |

--- a/stable/enterprise/tests/__snapshot__/prehook_upgrade_resources_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/prehook_upgrade_resources_test.yaml.snap
@@ -26,7 +26,7 @@ migration job should match snapshot:
               name: test-release-enterprise-config-env-vars
           - secretRef:
               name: test-release-enterprise
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: migrate-analysis-archive
         volumeMounts:
@@ -89,7 +89,7 @@ migration job should match snapshot:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: wait-for-db
     restartPolicy: Never
@@ -148,7 +148,7 @@ migration job should match snapshot analysisArchiveMigration and objectStoreMigr
               name: test-release-enterprise-config-env-vars
           - secretRef:
               name: test-release-enterprise
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: migrate-analysis-archive
         volumeMounts:
@@ -211,7 +211,7 @@ migration job should match snapshot analysisArchiveMigration and objectStoreMigr
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: wait-for-db
     restartPolicy: Never
@@ -268,7 +268,7 @@ migration job should match snapshot analysisArchiveMigration to true:
               name: test-release-enterprise-config-env-vars
           - secretRef:
               name: test-release-enterprise
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: migrate-analysis-archive
         volumeMounts:
@@ -331,7 +331,7 @@ migration job should match snapshot analysisArchiveMigration to true:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: wait-for-db
     restartPolicy: Never
@@ -387,7 +387,7 @@ migration job should match snapshot objectStoreMigration to true:
               name: test-release-enterprise-config-env-vars
           - secretRef:
               name: test-release-enterprise
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: migrate-analysis-archive
         volumeMounts:
@@ -450,7 +450,7 @@ migration job should match snapshot objectStoreMigration to true:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-        image: docker.io/anchore/enterprise:v5.8.0
+        image: docker.io/anchore/enterprise:v5.8.1
         imagePullPolicy: IfNotPresent
         name: wait-for-db
     restartPolicy: Never
@@ -621,6 +621,6 @@ should render proper initContainers:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-      image: docker.io/anchore/enterprise:v5.8.0
+      image: docker.io/anchore/enterprise:v5.8.1
       imagePullPolicy: IfNotPresent
       name: wait-for-db

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -19,7 +19,7 @@ global:
 
 ## @param image Image used for all Anchore Enterprise deployments, excluding Anchore UI
 ##
-image: docker.io/anchore/enterprise:v5.8.0
+image: docker.io/anchore/enterprise:v5.8.1
 
 ## @param imagePullPolicy Image pull policy used by all deployments
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy


### PR DESCRIPTION
feeds will need to be merged first, then update the dependency/lock on enterprise before this is merged.
https://github.com/anchore/anchore-charts/pull/394