### PR TITLE
use correct ssl mode in postgres URI

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "2.9.2"
+version: "2.9.3"
 appVersion: "5.8.1"
 kubeVersion: 1.23.x - 1.30.x || 1.23.x-x - 1.30.x-x
 description: |

--- a/stable/enterprise/templates/ui_secret.yaml
+++ b/stable/enterprise/templates/ui_secret.yaml
@@ -12,7 +12,7 @@ type: Opaque
 stringData:
 
 {{- if .Values.anchoreConfig.database.ssl }}
-  ANCHORE_APPDB_URI: 'postgresql://{{- template "enterprise.ui.dbUser" . -}}:{{- template "enterprise.ui.dbPassword" . -}}@{{ template "enterprise.dbHostname" . }}/{{ index .Values "postgresql" "auth" "database" }}?ssl={{- .Values.anchoreConfig.database.sslMode -}}'
+  ANCHORE_APPDB_URI: 'postgresql://{{- template "enterprise.ui.dbUser" . -}}:{{- template "enterprise.ui.dbPassword" . -}}@{{ template "enterprise.dbHostname" . }}/{{ index .Values "postgresql" "auth" "database" }}?sslMode={{- .Values.anchoreConfig.database.sslMode -}}'
 {{- else }}
   ANCHORE_APPDB_URI: 'postgresql://{{- template "enterprise.ui.dbUser" . -}}:{{- template "enterprise.ui.dbPassword" . -}}@{{ template "enterprise.dbHostname" . }}/{{ index .Values "postgresql" "auth" "database" }}'
 {{- end }}


### PR DESCRIPTION
@gnyahay could you take a look at this?

This should be `sslMode` not `ssl`
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE

