### PR TITLE
marks anchore-engine chart as deprecated clearly

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v2
 name: anchore-engine
-version: 1.28.7
+version: 1.28.8
 appVersion: 1.1.0
 description: Anchore container analysis and policy evaluation engine service
+deprecated: true
 keywords:
   - analysis
   - docker
@@ -15,11 +16,6 @@ keywords:
 home: https://anchore.com
 sources:
   - https://github.com/anchore/anchore-engine
-maintainers:
-  - name: zhill
-    email: zach@anchore.com
-  - name: btodhunter
-    email: bradyt@anchore.com
 engine: gotpl
 icon: https://anchoreprd.wpengine.com/wp-content/uploads/2021/12/favicon.png
 dependencies:

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -1,4 +1,7 @@
-# Anchore Helm Chart
+ 
+# **Deprecation warning: This chart is deprecated and is no longer maintained. The [Anchore Engine project](https://github.com/anchore/anchore-engine) is EOL as well. Please refer to Anchore Enterprise and the [enterprise](https://github.com/anchore/anchore-charts/tree/main/stable/enterprise) chart for Anchore deployments.**
+
+# Anchore Engine Helm Chart
 
 This chart deploys the Anchore Enterprise container image analysis system. Anchore requires a PostgreSQL database (>=9.6) which may be handled by the chart or supplied externally, and executes in a service-based architecture utilizing the following Anchore Enterprise services: External API, SimpleQueue, Catalog, Policy Engine, Analyzer, GUI, RBAC, Reporting, Notifications and On-premises Feeds. Enterprise services require a valid Anchore Enterprise license, as well as credentials with access to the private DockerHub repository hosting the images. These are not enabled by default.
 


### PR DESCRIPTION
Adds deprecation flag to engine chart and updates readme to clearly state this chart is deprecated.