### PR TITLE
use empty array for these values

### DIFF
--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -600,8 +600,8 @@ anchoreConfig:
     vulnerabilities:
       matching:
         exclude:
-          providers: null
-          package_types: null
+          providers: []
+          package_types: []
 
     ## @param anchoreConfig.policy_engine.enable_user_base_image Enables usage of Well Known Annotation to identify base image for use in ancestry calculations
     enable_user_base_image: true


### PR DESCRIPTION
I got the following error when applying the helm chart:

```
│ Error: execution error at (enterprise/templates/simplequeue_deployment.yaml:21:39): anchoreConfig.policy_engine.vulnerabilities.matching.exclude.providers is required
```

Changing the default value from `null` to `[]` (Empty array) fixes the issue.