### PR TITLE
chore: update osaaMigrationJobs kubectlImage

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.2.0"
+version: "3.2.1"
 appVersion: "5.12.0"
 kubeVersion: 1.23.x - 1.31.x || 1.23.x-x - 1.31.x-x
 description: |

--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.2.1"
+version: "3.2.2"
 appVersion: "5.12.0"
 kubeVersion: 1.23.x - 1.31.x || 1.23.x-x - 1.31.x-x
 description: |

--- a/stable/enterprise/tests/__snapshot__/prehook_upgrade_resources_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/prehook_upgrade_resources_test.yaml.snap
@@ -53,7 +53,7 @@ migration job should match snapshot:
         command:
           - /bin/bash
           - -c
-        image: bitnami/kubectl:1.27
+        image: bitnami/kubectl:1.30
         name: scale-down-anchore
       - args:
           - |
@@ -175,7 +175,7 @@ migration job should match snapshot analysisArchiveMigration and objectStoreMigr
         command:
           - /bin/bash
           - -c
-        image: bitnami/kubectl:1.27
+        image: bitnami/kubectl:1.30
         name: scale-down-anchore
       - args:
           - |
@@ -295,7 +295,7 @@ migration job should match snapshot analysisArchiveMigration to true:
         command:
           - /bin/bash
           - -c
-        image: bitnami/kubectl:1.27
+        image: bitnami/kubectl:1.30
         name: scale-down-anchore
       - args:
           - |
@@ -414,7 +414,7 @@ migration job should match snapshot objectStoreMigration to true:
         command:
           - /bin/bash
           - -c
-        image: bitnami/kubectl:1.27
+        image: bitnami/kubectl:1.30
         name: scale-down-anchore
       - args:
           - |

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -1759,7 +1759,7 @@ osaaMigrationJob:
   ## @param osaaMigrationJob.kubectlImage The image to use for the job's init container that uses kubectl to scale down deployments for the migration
   ## This is only used in the osaaMigrationJob job.
   ##
-  kubectlImage: bitnami/kubectl:1.27
+  kubectlImage: bitnami/kubectl:1.30
 
   ## @param osaaMigrationJob.extraEnv An array to add extra environment variables
   ##


### PR DESCRIPTION
updates the kubectlImage for osaaMigrationJob from 1.27 to 1.30