### PR TITLE
Fix custom_message with non-alphanumeric characters

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.3.3"
+version: "3.3.4"
 appVersion: "5.13.1"
 kubeVersion: 1.23.x - 1.31.x || 1.23.x-x - 1.31.x-x
 description: |

--- a/stable/enterprise/templates/ui_configmap.yaml
+++ b/stable/enterprise/templates/ui_configmap.yaml
@@ -23,8 +23,8 @@ data:
   {{- end }}
   {{- with .Values.anchoreConfig.ui.custom_message }}
     custom_message:
-      title: {{ .title }}
-      message: {{ .message }}
+      title: '{{ .title }}'
+      message: '{{ .message }}'
   {{- end }}
   {{- with .Values.anchoreConfig.ui.enable_add_repositories }}
     enable_add_repositories:

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -753,6 +753,7 @@ anchoreConfig:
 
     ## @param anchoreConfig.ui.custom_message.title A title key, whose string value provides a title for the message
     ## @param anchoreConfig.ui.custom_message.message A message key, whose string value is the message itself
+    ## NOTE: You may need to HTML encode the title and/or message if there are any non-alphanumeric characters present.
     ##
     custom_message: {}
       # title: "Title goes here..."


### PR DESCRIPTION
Add quotes to the custom message in the helm chart template for UI config map.
Along with HTML encoding the message the following error is fixed:
```
/home/node/aui/build/node_modules/js-yaml/lib/loader.js:183
  return new YAMLException(message, mark);
         ^
YAMLException: bad indentation of a mapping entry (15:229)
 12 |  ... 
 13 |  ... 
 14 |  ... 
 15 |  ... nt to the following conditions: - The USG routinely intercept ...
-----------------------------------------^
 16 |  ... 
 17 |  ... 
    at generateError (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:183:10)
    at throwError (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:187:9)
    at readBlockMapping (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:1182:7)
    at composeNode (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:1441:12)
    at readBlockMapping (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:1164:11)
    at composeNode (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:1441:12)
    at readDocument (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:1625:3)
    at loadDocuments (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:1688:5)
    at Object.yaml (/home/node/aui/build/node_modules/js-yaml/lib/loader.js:1714:19)
    at /anchore-on-prem-ui/src/config/configYaml.js:18:19
```