### PR TITLE
chore: bump k8s-inventory version to v1.7.3

### DIFF
--- a/stable/k8s-inventory/Chart.yaml
+++ b/stable/k8s-inventory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8s-inventory
 version: 0.5.1
-appVersion: "1.7.3"
+appVersion: "1.7.4"
 description: A Helm chart for Kubernetes Automated Inventory, which describes which images are in use in a given Kubernetes Cluster
 keywords:
   - analysis

--- a/stable/k8s-inventory/Chart.yaml
+++ b/stable/k8s-inventory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8s-inventory
-version: 0.5.0
-appVersion: "1.7.1"
+version: 0.5.1
+appVersion: "1.7.3"
 description: A Helm chart for Kubernetes Automated Inventory, which describes which images are in use in a given Kubernetes Cluster
 keywords:
   - analysis

--- a/stable/k8s-inventory/values.yaml
+++ b/stable/k8s-inventory/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 image:
   pullPolicy: "IfNotPresent"
   repository: "anchore/k8s-inventory"
-  tag: "v1.7.1"
+  tag: "v1.7.3"
 
 ## @param imagePullSecrets secrets where Kubernetes should get the credentials for pulling private images
 ##

--- a/stable/k8s-inventory/values.yaml
+++ b/stable/k8s-inventory/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 image:
   pullPolicy: "IfNotPresent"
   repository: "anchore/k8s-inventory"
-  tag: "v1.7.3"
+  tag: "v1.7.4"
 
 ## @param imagePullSecrets secrets where Kubernetes should get the credentials for pulling private images
 ##


### PR DESCRIPTION
Before this merged, we released a v1.7.4 of k8s-inventory