### PR TITLE
Update envvars_configmap.yaml

### DIFF
--- a/stable/enterprise/templates/envvars_configmap.yaml
+++ b/stable/enterprise/templates/envvars_configmap.yaml
@@ -83,7 +83,7 @@ data:
   ANCHORE_OAUTH_TOKEN_EXPIRATION: "{{ .Values.anchoreConfig.user_authentication.oauth.default_token_expiration_seconds }}"
   ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION: "{{ .Values.anchoreConfig.user_authentication.oauth.refresh_token_expiration_seconds }}"
   ANCHORE_OWNED_PACKAGE_FILTERING_ENABLED: "true"
-  ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD: "true"
+  ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD: "false"
   ANCHORE_POLICY_EVAL_CACHE_TTL_SECONDS: "3600"
   ANCHORE_SAML_SECRET: "null"
   ANCHORE_SERVICE_DIR: "{{ .Values.anchoreConfig.service_dir }}"


### PR DESCRIPTION
change default for new installs - must then be explicitly enabled in order to use  "packages" gate and "verify" trigger