### PR TITLE
Enterprise dependent chart pullcreds

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -58,7 +58,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '20 7 * * 2'
   push:
-    branches: ["main", "enterprise-dependent-chart-pullcreds"]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '20 7 * * 2'
   push:
-    branches: ["main"]
+    branches: ["main", "enterprise-dependent-chart-pullcreds"]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.7.3"
+version: "3.7.4"
 appVersion: "5.17.0"
 kubeVersion: 1.23.x - 1.32.x || 1.23.x-x - 1.32.x-x
 description: |

--- a/stable/enterprise/tests/__snapshot__/dependency_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/dependency_test.yaml.snap
@@ -1,0 +1,216 @@
+should render defaults:
+  1: |
+    affinity:
+      nodeAffinity: null
+      podAffinity: null
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: primary
+                  app.kubernetes.io/instance: test-release
+                  app.kubernetes.io/name: postgresql
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+    containers:
+      - env:
+          - name: BITNAMI_DEBUG
+            value: "false"
+          - name: POSTGRESQL_PORT_NUMBER
+            value: "5432"
+          - name: POSTGRESQL_VOLUME_DIR
+            value: /bitnami/postgresql
+          - name: PGDATA
+            value: /bitnami/postgresql/data
+          - name: POSTGRES_USER
+            value: anchore
+          - name: POSTGRES_POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: postgres-password
+                name: test-release-postgresql
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: test-release-postgresql
+          - name: POSTGRES_DB
+            value: anchore
+          - name: POSTGRESQL_ENABLE_LDAP
+            value: "no"
+          - name: POSTGRESQL_ENABLE_TLS
+            value: "no"
+          - name: POSTGRESQL_LOG_HOSTNAME
+            value: "false"
+          - name: POSTGRESQL_LOG_CONNECTIONS
+            value: "false"
+          - name: POSTGRESQL_LOG_DISCONNECTIONS
+            value: "false"
+          - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+            value: "off"
+          - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+            value: error
+          - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+            value: pgaudit
+        image: docker.io/bitnami/postgresql:13.11.0-debian-11-r15
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - exec pg_isready -U "anchore" -d "dbname=anchore" -h 127.0.0.1 -p 5432
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: postgresql
+        ports:
+          - containerPort: 5432
+            name: tcp-postgresql
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - -e
+              - |
+                exec pg_isready -U "anchore" -d "dbname=anchore" -h 127.0.0.1 -p 5432
+                [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+          failureThreshold: 6
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          limits: {}
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        securityContext:
+          runAsUser: 1001
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
+          - mountPath: /bitnami/postgresql
+            name: data
+    hostIPC: false
+    hostNetwork: false
+    imagePullSecrets:
+      - name: anchore-enterprise-pullcreds
+    securityContext:
+      fsGroup: 1001
+    serviceAccountName: default
+    volumes:
+      - emptyDir:
+          medium: Memory
+        name: dshm
+  2: |
+    affinity:
+      nodeAffinity: null
+      podAffinity: null
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: master
+                  app.kubernetes.io/instance: test-release
+                  app.kubernetes.io/name: ui-redis
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+    automountServiceAccountToken: true
+    containers:
+      - args:
+          - -c
+          - /opt/bitnami/scripts/start-scripts/start-master.sh
+        command:
+          - /bin/bash
+        env:
+          - name: BITNAMI_DEBUG
+            value: "false"
+          - name: REDIS_REPLICATION_MODE
+            value: master
+          - name: ALLOW_EMPTY_PASSWORD
+            value: "no"
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: redis-password
+                name: test-release-ui-redis
+          - name: REDIS_TLS_ENABLED
+            value: "no"
+          - name: REDIS_PORT
+            value: "6379"
+        image: docker.io/bitnami/redis:7.0.12-debian-11-r0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/ping_liveness_local.sh 5
+          failureThreshold: 5
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 6
+        name: redis
+        ports:
+          - containerPort: 6379
+            name: redis
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+          limits: {}
+          requests: {}
+        securityContext:
+          runAsUser: 1001
+        volumeMounts:
+          - mountPath: /opt/bitnami/scripts/start-scripts
+            name: start-scripts
+          - mountPath: /health
+            name: health
+          - mountPath: /data
+            name: redis-data
+          - mountPath: /opt/bitnami/redis/mounted-etc
+            name: config
+          - mountPath: /opt/bitnami/redis/etc/
+            name: redis-tmp-conf
+          - mountPath: /tmp
+            name: tmp
+    imagePullSecrets:
+      - name: anchore-enterprise-pullcreds
+    securityContext:
+      fsGroup: 1001
+    serviceAccountName: test-release-ui-redis
+    terminationGracePeriodSeconds: 30
+    volumes:
+      - configMap:
+          defaultMode: 493
+          name: test-release-ui-redis-scripts
+        name: start-scripts
+      - configMap:
+          defaultMode: 493
+          name: test-release-ui-redis-health
+        name: health
+      - configMap:
+          name: test-release-ui-redis-configuration
+        name: config
+      - emptyDir: {}
+        name: redis-tmp-conf
+      - emptyDir: {}
+        name: tmp
+      - emptyDir: {}
+        name: redis-data

--- a/stable/enterprise/tests/dependency_test.yaml
+++ b/stable/enterprise/tests/dependency_test.yaml
@@ -1,0 +1,51 @@
+suite: Dependency Resource Tests
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+
+tests:
+  - it: should render defaults
+    documentIndex: 0
+    templates:
+      - charts/postgresql/templates/primary/statefulset.yaml
+      - charts/ui-redis/templates/master/application.yaml
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec
+
+  - it: should render the pullcreds by default
+    templates:
+      - charts/postgresql/templates/primary/statefulset.yaml
+      - charts/ui-redis/templates/master/application.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: anchore-enterprise-pullcreds
+
+  - it: should render the pullcreds when specified for postgresql
+    templates:
+      - charts/postgresql/templates/primary/statefulset.yaml
+    set:
+      postgresql.image.pullSecrets:
+        - myCustomPullcreds
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: myCustomPullcreds
+
+  - it: should render the pullcreds when specified for ui-redis
+    templates:
+      - charts/ui-redis/templates/master/application.yaml
+    set:
+      ui-redis.image.pullSecrets:
+        - myCustomPullcreds
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: myCustomPullcreds

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -1766,11 +1766,14 @@ ui-redis:
   ## @param ui-redis.image.registry Specifies the image registry to use for this chart.
   ## @param ui-redis.image.repository Specifies the image repository to use for this chart.
   ## @param ui-redis.image.tag Specifies the image to use for this chart.
+  ## @param ui-redis.image.pullSecrets Specifies the image pull secrets to use for this chart.
   ##
   image:
     registry: docker.io
     repository: bitnami/redis
     tag: 7.0.12-debian-11-r0
+    pullSecrets:
+      - anchore-enterprise-pullcreds
 
 #######################################
 ## @section Anchore Database Parameters
@@ -1826,11 +1829,14 @@ postgresql:
   ## @param postgresql.image.repository Specifies the image repository to use for this chart.
   ## @param postgresql.image.registry Specifies the image registry to use for this chart.
   ## @param postgresql.image.tag Specifies the image to use for this chart.
+  ## @param postgresql.image.pullSecrets Specifies the image pull secrets to use for this chart.
   ##
   image:
     repository: bitnami/postgresql
     registry: docker.io
     tag: 13.11.0-debian-11-r15
+    pullSecrets:
+      - anchore-enterprise-pullcreds
 
 ########################################################################################
 ## @section Anchore Object Store and Analysis Archive Migration


### PR DESCRIPTION
This helps get around dockerhub's rate limiting. If you have credentials to pull enterprise, we can use those same credentials to pull the redis and postgresql images. 

If the customer is already overriding it due to running into the rate limiting issues, then their override would already take priority over whats in the default values.yaml.