### PR TITLE
[ENTERPRISE-5770]: feat: add support for config-ui banners into the Enterprise helm chart (#469)

### DIFF
--- a/.github/workflows/openshift-test.yaml
+++ b/.github/workflows/openshift-test.yaml
@@ -168,7 +168,7 @@ jobs:
         else
           echo "updating nightly-values.yaml with nightly image"
           echo 'image: "docker.io/anchore/enterprise-dev:nightly"' >> stable/enterprise/ci/nightly-values.yaml
-          echo 'ui:' >> stable/enterprise/ci/rc-values.yaml
+          echo 'ui:' >> stable/enterprise/ci/nightly-values.yaml
           echo '  image: "docker.io/anchore/anchore-on-prem-ui-dev:nightly"' >> stable/enterprise/ci/nightly-values.yaml
           echo "Appended to stable/enterprise/ci/nightly-values.yaml"
         fi

--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.10.0"
+version: "3.10.1"
 appVersion: "5.18.0"
 kubeVersion: 1.23.x - 1.32.x || 1.23.x-x - 1.32.x-x
 description: |

--- a/stable/enterprise/templates/ui_configmap.yaml
+++ b/stable/enterprise/templates/ui_configmap.yaml
@@ -26,6 +26,23 @@ data:
       title: '{{ .title }}'
       message: '{{ .message }}'
   {{- end }}
+  {{- with .Values.anchoreConfig.ui.banners }}
+    banners:
+      {{- with .top }}
+      top:
+        text: {{ default "" .text | quote }}
+        text_color: {{ default "" .text_color | quote}}
+        background_color: {{ default "" .background_color | quote }}
+        display: {{ default "always" .display | quote }}
+      {{- end }}
+      {{- with .bottom }}
+      bottom:
+        text: {{ default "" .text | quote }}
+        text_color: {{ default "" .text_color | quote}}
+        background_color: {{ default "" .background_color | quote }}
+        display: {{ default "always" .display | quote }}
+      {{- end }}
+  {{- end }}
   {{- with .Values.anchoreConfig.ui.enable_add_repositories }}
     enable_add_repositories:
       admin: {{ .admin }}

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -784,6 +784,28 @@ anchoreConfig:
       # title: "Title goes here..."
       # message: "Message goes here..."
 
+    ## @param anchoreConfig.ui.banners Provide messages that will be displayed as a banner at the top and/or bottom of the application or only the login page.
+    ## anchoreConfig.ui.banners.top
+    ## anchoreConfig.ui.banners.bottom
+    ## You can set either or both banners. Each banner is defined by a key that contains an object with the following properties:
+    ## - `text` (string): The message to be displayed in the banner. This can be up to `2000` characters long.
+    ## - `text_color` (string): The color of the text in the banner.
+    ## - `background_color` (string): The background color of the banner.
+    ## - `display` (string): The display condition for the banner. This can be set to `always` or `login-only`. If not specified, the default is `always`. The `login-only` option will only display the banner on the login page.
+    ## NOTE: You may need to HTML encode the text if there are any non-alphanumeric characters present.
+    ##
+    banners: {}
+      # top:
+      #   text: "Custom message for the top banner..."
+      #   text_color: ""
+      #   background_color: ""
+      #   display: "always"
+      # bottom:
+      #   text: "Custom message for the bottom banner..."
+      #   text_color: ""
+      #   background_color: ""
+      #   display: "login-only"
+
     ## @param anchoreConfig.ui.log_level Descriptive detail of the application log output
     ## valid values are error, warn, info, http, debug
     ##


### PR DESCRIPTION
* feat: add support for config-ui banners into the Enterprise helm chart
