### PR TITLE
Render endpoint hostnames as a formal FQDN

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.10.0"
+version: "3.11.0"
 appVersion: "5.18.0"
 kubeVersion: 1.23.x - 1.32.x || 1.23.x-x - 1.32.x-x
 description: |

--- a/stable/enterprise/templates/_common.tpl
+++ b/stable/enterprise/templates/_common.tpl
@@ -120,7 +120,7 @@ When calling this template, .component can be included in the context for compon
 {{- end }}
 
 - name: ANCHORE_ENDPOINT_HOSTNAME
-  value: {{ $serviceName }}.{{- if $domainSuffix -}}{{ $domainSuffix }}{{- else -}}{{ .Release.Namespace }}.svc.cluster.local{{- end }}
+  value: {{ $serviceName }}.{{- if $domainSuffix -}}{{ $domainSuffix }}{{- else -}}{{ .Release.Namespace }}.svc.cluster.local.{{- end }}
 
   {{- with (index .Values (print $component)).service }}
 - name: ANCHORE_PORT

--- a/stable/enterprise/tests/__snapshot__/prehook_upgrade_resources_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/prehook_upgrade_resources_test.yaml.snap
@@ -14,7 +14,7 @@ migration job should match snapshot:
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -82,7 +82,7 @@ migration job should match snapshot:
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -136,7 +136,7 @@ migration job should match snapshot analysisArchiveMigration and objectStoreMigr
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -204,7 +204,7 @@ migration job should match snapshot analysisArchiveMigration and objectStoreMigr
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -256,7 +256,7 @@ migration job should match snapshot analysisArchiveMigration to true:
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -324,7 +324,7 @@ migration job should match snapshot analysisArchiveMigration to true:
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -375,7 +375,7 @@ migration job should match snapshot objectStoreMigration to true:
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -443,7 +443,7 @@ migration job should match snapshot objectStoreMigration to true:
           - name: bar
             value: baz
           - name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local
+            value: test-release-enterprise-999-osaa-migration-job.test-namespace.svc.cluster.local.
           - name: ANCHORE_PORT
             value: "null"
           - name: ANCHORE_HOST_ID
@@ -614,7 +614,7 @@ should render proper initContainers:
         - name: bar
           value: baz
         - name: ANCHORE_ENDPOINT_HOSTNAME
-          value: test-release-enterprise-999-upgrade.test-namespace.svc.cluster.local
+          value: test-release-enterprise-999-upgrade.test-namespace.svc.cluster.local.
         - name: ANCHORE_PORT
           value: "null"
         - name: ANCHORE_HOST_ID

--- a/stable/enterprise/tests/analyzer_resources_test.yaml
+++ b/stable/enterprise/tests/analyzer_resources_test.yaml
@@ -221,7 +221,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-analyzer.test-namespace.svc.cluster.local
+            value: test-release-enterprise-analyzer.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -411,7 +411,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-analyzer.test-namespace.svc.cluster.local
+            value: test-release-enterprise-analyzer.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: analyzer_deployment.yaml

--- a/stable/enterprise/tests/api_resources_test.yaml
+++ b/stable/enterprise/tests/api_resources_test.yaml
@@ -203,7 +203,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-api.test-namespace.svc.cluster.local
+            value: test-release-enterprise-api.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -508,7 +508,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-api.test-namespace.svc.cluster.local
+            value: test-release-enterprise-api.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: api_deployment.yaml

--- a/stable/enterprise/tests/catalog_resources_test.yaml
+++ b/stable/enterprise/tests/catalog_resources_test.yaml
@@ -236,7 +236,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-catalog.test-namespace.svc.cluster.local
+            value: test-release-enterprise-catalog.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -521,7 +521,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-catalog.test-namespace.svc.cluster.local
+            value: test-release-enterprise-catalog.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: catalog_deployment.yaml
@@ -547,7 +547,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-catalog.myothersuffix.svc.cluster.local
+            value: test-release-enterprise-catalog.myothersuffix.svc.cluster.local.
 
   - it: should render component topologySpreadConstraints
     documentIndex: 0

--- a/stable/enterprise/tests/datasyncer_resources_test.yaml
+++ b/stable/enterprise/tests/datasyncer_resources_test.yaml
@@ -242,7 +242,7 @@ tests:
           path: spec.template.spec.containers[0].env[0]
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-datasyncer.test-namespace.svc.cluster.local
+            value: test-release-enterprise-datasyncer.test-namespace.svc.cluster.local.
         count: 1
       - isSubset:
           path: spec.template.spec.containers[0].env[1]

--- a/stable/enterprise/tests/notifications_resources_test.yaml
+++ b/stable/enterprise/tests/notifications_resources_test.yaml
@@ -178,7 +178,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-notifications.test-namespace.svc.cluster.local
+            value: test-release-enterprise-notifications.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -426,7 +426,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-notifications.test-namespace.svc.cluster.local
+            value: test-release-enterprise-notifications.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: notifications_deployment.yaml

--- a/stable/enterprise/tests/policyengine_resources_test.yaml
+++ b/stable/enterprise/tests/policyengine_resources_test.yaml
@@ -220,7 +220,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-policy.test-namespace.svc.cluster.local
+            value: test-release-enterprise-policy.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -480,7 +480,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-policy.test-namespace.svc.cluster.local
+            value: test-release-enterprise-policy.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: policyengine_deployment.yaml

--- a/stable/enterprise/tests/reports_resources_test.yaml
+++ b/stable/enterprise/tests/reports_resources_test.yaml
@@ -176,7 +176,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-reports.test-namespace.svc.cluster.local
+            value: test-release-enterprise-reports.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -539,7 +539,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-reports.test-namespace.svc.cluster.local
+            value: test-release-enterprise-reports.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: reports_deployment.yaml

--- a/stable/enterprise/tests/reportsworker_resources_test.yaml
+++ b/stable/enterprise/tests/reportsworker_resources_test.yaml
@@ -176,7 +176,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-reportsworker.test-namespace.svc.cluster.local
+            value: test-release-enterprise-reportsworker.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -424,7 +424,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-reportsworker.test-namespace.svc.cluster.local
+            value: test-release-enterprise-reportsworker.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: reportsworker_deployment.yaml

--- a/stable/enterprise/tests/simplequeue_resources_test.yaml
+++ b/stable/enterprise/tests/simplequeue_resources_test.yaml
@@ -176,7 +176,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-simplequeue.test-namespace.svc.cluster.local
+            value: test-release-enterprise-simplequeue.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -399,7 +399,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-simplequeue.test-namespace.svc.cluster.local
+            value: test-release-enterprise-simplequeue.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: simplequeue_deployment.yaml

--- a/stable/enterprise/tests/ui_resources_test.yaml
+++ b/stable/enterprise/tests/ui_resources_test.yaml
@@ -191,7 +191,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-ui.test-namespace.svc.cluster.local
+            value: test-release-enterprise-ui.test-namespace.svc.cluster.local.
         count: 1
       - contains:
           path: spec.template.spec.containers[0].env
@@ -460,7 +460,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ANCHORE_ENDPOINT_HOSTNAME
-            value: test-release-enterprise-ui.test-namespace.svc.cluster.local
+            value: test-release-enterprise-ui.test-namespace.svc.cluster.local.
 
   - it: should render ANCHORE_ENDPOINT_HOSTNAME with toplevel domainSuffix
     template: ui_deployment.yaml


### PR DESCRIPTION
Our hostnames in a kubernetes environment should be treated as an FQDN but because they do not end in a dot they are treated as partial hostnames. When a DNS lookup is performed for service to service communication 5 lookups are required. By the 5th lookup it is assumed to be an FQDN. By adding a trailing dot only 1 lookup will be required. There is still an ability to overwrite the domainSuffix in the event someone needs the former behavior.