### PR TITLE
enterprise: Fix configmap unittests

### DIFF
--- a/stable/enterprise/files/default_config.yaml
+++ b/stable/enterprise/files/default_config.yaml
@@ -64,7 +64,7 @@ webhooks: {{- toYaml .Values.anchoreConfig.webhooks | nindent 2 }}
 default_admin_password: "${ANCHORE_ADMIN_PASSWORD}"
 default_admin_email: ${ANCHORE_ADMIN_EMAIL}
 
-configuration: 
+configuration:
   api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}
 
 keys:

--- a/stable/enterprise/files/osaa_config.yaml
+++ b/stable/enterprise/files/osaa_config.yaml
@@ -64,7 +64,7 @@ webhooks: {{- toYaml .Values.anchoreConfig.webhooks | nindent 2 }}
 default_admin_password: "${ANCHORE_ADMIN_PASSWORD}"
 default_admin_email: ${ANCHORE_ADMIN_EMAIL}
 
-configuration: 
+configuration:
   api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}
 
 keys:

--- a/stable/enterprise/templates/ui_configmap.yaml
+++ b/stable/enterprise/templates/ui_configmap.yaml
@@ -62,7 +62,7 @@ data:
     authentication_lock:
       count: {{ .Values.anchoreConfig.ui.authentication_lock.count }}
       expires: {{ .Values.anchoreConfig.ui.authentication_lock.expires }}
-    appdb_config: {{ toYaml .Values.anchoreConfig.ui.appdb_config | nindent 6}}
+    appdb_config: {{- toYaml .Values.anchoreConfig.ui.appdb_config | nindent 6}}
     log_level: {{ .Values.anchoreConfig.ui.log_level | squote }}
     enrich_inventory_view: {{ .Values.anchoreConfig.ui.enrich_inventory_view  }}
     enable_prometheus_metrics: {{ .Values.anchoreConfig.metrics.enabled }}

--- a/stable/enterprise/tests/__snapshot__/configmap_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/configmap_test.yaml.snap
@@ -42,7 +42,373 @@ should render the configmaps:
   2: |
     apiVersion: v1
     data:
-      config.yaml: "# Anchore Service Configuration File, mounted from a configmap\n#\nservice_dir: ${ANCHORE_SERVICE_DIR}\ntmp_dir: ${ANCHORE_TMP_DIR}\nlog_level: ${ANCHORE_LOG_LEVEL} # Deprecated - prefer use of logging.log_level\n\nlogging:\n  colored_logging: false\n  exception_backtrace_logging: false\n  exception_diagnose_logging: false\n  file_retention_rule: 10\n  file_rotation_rule: 10 MB\n  log_level: <ALLOW_API_CONFIGURATION>\n  server_access_logging: true\n  server_log_level: info\n  server_response_debug_logging: false\n  structured_logging: false\n\nserver:\n  max_connection_backlog: 2048\n  max_wsgi_middleware_worker_count: 50\n  max_wsgi_middleware_worker_queue_size: 100\n  timeout_graceful_shutdown: false\n  timeout_keep_alive: 5\n\nallow_awsecr_iam_auto: ${ANCHORE_ALLOW_ECR_IAM_AUTO}\nhost_id: \"${ANCHORE_HOST_ID}\"\ninternal_ssl_verify: ${ANCHORE_INTERNAL_SSL_VERIFY}\nimage_analyze_timeout_seconds: ${ANCHORE_IMAGE_ANALYZE_TIMEOUT_SECONDS}\n\nglobal_client_connect_timeout: ${ANCHORE_GLOBAL_CLIENT_CONNECT_TIMEOUT}\nglobal_client_read_timeout: ${ANCHORE_GLOBAL_CLIENT_READ_TIMEOUT}\nserver_request_timeout_seconds: ${ANCHORE_GLOBAL_SERVER_REQUEST_TIMEOUT_SEC}\n\nlicense_file: ${ANCHORE_LICENSE_FILE}\nauto_restart_services: false\n\nmax_source_import_size_mb: ${ANCHORE_MAX_IMPORT_SOURCE_SIZE_MB}\nmax_import_content_size_mb: ${ANCHORE_MAX_IMPORT_CONTENT_SIZE_MB}\n\nmax_compressed_image_size_mb: ${ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB}\n\naudit:\n  enabled: true\n  mode: log\n  verbs:\n    - post\n    - put\n    - delete\n    - patch\n  resource_uris:\n    - \"/accounts\"\n    - \"/accounts/{account_name}\"\n    - \"/accounts/{account_name}/state\"\n    - \"/accounts/{account_name}/users\"\n    - \"/accounts/{account_name}/users/{username}\"\n    - \"/accounts/{account_name}/users/{username}/api-keys\"\n    - \"/accounts/{account_name}/users/{username}/api-keys/{key_name}\"\n    - \"/accounts/{account_name}/users/{username}/credentials\"\n    - \"/rbac-manager/roles\"\n    - \"/rbac-manager/roles/{role_name}/members\"\n    - \"/rbac-manager/saml/idps\"\n    - \"/rbac-manager/saml/idps/{name}\"\n    - \"/rbac-manager/saml/idps/{name}/user-group-mappings\"\n    - \"/system/user-groups\"\n    - \"/system/user-groups/{group_uuid}\"\n    - \"/system/user-groups/{group_uuid}/roles\"\n    - \"/system/user-groups/{group_uuid}/users\"\n    - \"/user/api-keys\"\n    - \"/user/api-keys/{key_name}\"\n    - \"/user/credentials\"\n\nmetrics:\n  enabled: ${ANCHORE_ENABLE_METRICS}\n  auth_disabled: ${ANCHORE_DISABLE_METRICS_AUTH}\n\nwebhooks:\n  {}\n\ndefault_admin_password: \"${ANCHORE_ADMIN_PASSWORD}\"\ndefault_admin_email: ${ANCHORE_ADMIN_EMAIL}\n\nconfiguration: \n  api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}\n\nkeys:\n  secret: \"${ANCHORE_SAML_SECRET}\"\n  public_key_path: ${ANCHORE_AUTH_PRIVKEY}\n  private_key_path: ${ANCHORE_AUTH_PUBKEY}\n\nuser_authentication:\n  oauth:\n    enabled: ${ANCHORE_OAUTH_ENABLED}\n    default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}\n    refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}\n  hashed_passwords: ${ANCHORE_AUTH_ENABLE_HASHED_PASSWORDS}\n  sso_require_existing_users: ${ANCHORE_SSO_REQUIRES_EXISTING_USERS}\n  allow_api_keys_for_saml_users: false\n  max_api_key_age_days: 365\n  max_api_keys_per_user: 100\n  remove_deleted_user_api_keys_older_than_days: 365\n  disallow_native_users: false\n  log_saml_assertions: false\ncredentials:\n  database:\n    user: \"${ANCHORE_DB_USER}\"\n    password: \"${ANCHORE_DB_PASSWORD}\"\n    host: \"${ANCHORE_DB_HOST}\"\n    port: \"${ANCHORE_DB_PORT}\"\n    name: \"${ANCHORE_DB_NAME}\"\n    db_connect_args:\n      timeout: ${ANCHORE_DB_TIMEOUT}\n      ssl: ${ANCHORE_DB_SSL}\n    db_pool_size: ${ANCHORE_DB_POOL_SIZE}\n    db_pool_max_overflow: ${ANCHORE_DB_POOL_MAX_OVERFLOW}\n\naccount_gc:\n  max_resource_gc_chunk: 4096\n  max_deletion_threads: 4\n\nservices:\n  apiext:\n    enabled: true\n    image_content:\n      remove_license_content_from_sbom_return: <ALLOW_API_CONFIGURATION>\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  analyzer:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    cycle_timer_seconds: 1\n    cycle_timers:\n      image_analyzer: 1\n    analyzer_driver: 'nodocker'\n    layer_cache_enable: ${ANCHORE_LAYER_CACHE_ENABLED}\n    layer_cache_max_gigabytes: ${ANCHORE_LAYER_CACHE_SIZE_GB}\n    enable_hints: ${ANCHORE_HINTS_ENABLED}\n    enable_owned_package_filtering: ${ANCHORE_OWNED_PACKAGE_FILTERING_ENABLED}\n    keep_image_analysis_tmpfiles: ${ANCHORE_KEEP_IMAGE_ANALYSIS_TMPFILES}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  catalog:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    account_prometheus_metrics: <ALLOW_API_CONFIGURATION>\n    cycle_timer_seconds: 1\n    cycle_timers:\n      analyzer_queue: 1\n      archive_tasks: 43200\n      artifact_lifecycle_policy_tasks: 43200\n      events_gc: 43200\n      image_gc: 60\n      image_watcher: 3600\n      k8s_image_watcher: 150\n      notifications: 30\n      policy_bundle_sync: 300\n      policy_eval: 3600\n      repo_watcher: 60\n      resource_metrics: 60\n      service_watcher: 15\n      vulnerability_scan: 14400\n    event_log:\n      max_retention_age_days: 180\n      notification:\n        enabled: false\n        level:\n        - error\n    runtime_inventory:\n      inventory_ttl_days: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_TTL_DAYS}\n      inventory_ingest_overwrite: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_INGEST_OVERWRITE}\n    integrations:\n      integration_health_report_ttl_days: ${ANCHORE_ENTERPRISE_INTEGRATION_HEALTH_REPORTS_TTL_DAYS}\n    image_gc:\n      max_worker_threads: ${ANCHORE_CATALOG_IMAGE_GC_WORKERS}\n    runtime_compliance:\n      object_store_bucket: \"runtime_compliance_check\"\n    down_analyzer_task_requeue: ${ANCHORE_ANALYZER_TASK_REQUEUE}\n    import_operation_expiration_days: ${ANCHORE_IMPORT_OPERATION_EXPIRATION_DAYS}\n    sbom_vuln_scan:\n      auto_scale: true\n      batch_size: 1\n      pool_size: 1\n    analysis_archive:\n      {}\n    object_store:\n      compression:\n        enabled: true\n        min_size_kbytes: 100\n      storage_driver:\n        config: {}\n        name: db\n      verify_content_digests: true\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  simplequeue:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  policy_engine:\n    enabled: true\n    require_auth: true\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    policy_evaluation_cache_ttl: ${ANCHORE_POLICY_EVAL_CACHE_TTL_SECONDS}\n    enable_package_db_load: ${ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD}\n    enable_user_base_image: true\n    vulnerabilities:\n      sync:\n        enabled: true\n        ssl_verify: ${ANCHORE_FEEDS_SSL_VERIFY}\n        connection_timeout_seconds: 3\n        read_timeout_seconds: 60\n        data:\n          grypedb:\n            enabled: true\n      matching:\n        exclude:\n          providers: []\n          package_types: []\n        default:\n          search:\n            by_cpe:\n              enabled: ${ANCHORE_VULN_MATCHING_DEFAULT_SEARCH_BY_CPE_ENABLED}\n        ecosystem_specific:\n          dotnet:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_DOTNET_SEARCH_BY_CPE_ENABLED}\n          golang:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_GOLANG_SEARCH_BY_CPE_ENABLED}\n          java:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVA_SEARCH_BY_CPE_ENABLED}\n          javascript:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVASCRIPT_SEARCH_BY_CPE_ENABLED}\n          python:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_PYTHON_SEARCH_BY_CPE_ENABLED}\n          ruby:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_RUBY_SEARCH_BY_CPE_ENABLED}\n          stock:\n            search:\n              by_cpe:\n                # Disabling search by CPE for the stock matcher will entirely disable binary-only matches and is not advised\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_STOCK_SEARCH_BY_CPE_ENABLED}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  reports:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    enable_graphiql: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_GRAPHIQL}\n    cycle_timers:\n      reports_scheduled_queries: 600\n    max_async_execution_threads: ${ANCHORE_ENTERPRISE_REPORTS_MAX_ASYNC_EXECUTION_THREADS}\n    async_execution_timeout: ${ANCHORE_ENTERPRISE_REPORTS_ASYNC_EXECUTION_TIMEOUT}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n    use_volume: false\n\n  reports_worker:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    enable_data_ingress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_INGRESS}\n    enable_data_egress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_EGRESS}\n    data_egress_window: ${ANCHORE_ENTERPRISE_REPORTS_DATA_EGRESS_WINDOW}\n    data_refresh_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_REFRESH_MAX_WORKERS}\n    data_load_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_LOAD_MAX_WORKERS}\n    cycle_timers:\n      reports_extended_runtime_vuln_load: 1800\n      reports_image_egress: 600\n      reports_image_load: 600\n      reports_image_refresh: 7200\n      reports_metrics: 3600\n      reports_runtime_inventory_load: 600\n      reports_tag_egress: 600\n      reports_tag_load: 600\n      reports_tag_refresh: 7200\n    runtime_report_generation:\n      use_legacy_loaders_and_queries: false\n      inventory_images_by_vulnerability: true\n      vulnerabilities_by_k8s_namespace: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_NAMESPACE}\n      vulnerabilities_by_k8s_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_CONTAINER}\n      vulnerabilities_by_ecs_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_ECS_CONTAINER}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  notifications:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    cycle_timers:\n      notifications: 30\n    ui_url: ${ANCHORE_ENTERPRISE_UI_URL}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  data_syncer:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: 0.0.0.0\n    port: ${ANCHORE_PORT}\n    auto_sync_enabled: ${ANCHORE_DATA_SYNC_AUTO_SYNC_ENABLED}\n    upload_dir: /analysis_scratch\n    datasets:\n      vulnerability_db:\n        versions: [\"5\"]\n      clamav_db:\n        versions: [\"1\"]\n      kev_db:\n        versions: [\"1\"]\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n"
+      config.yaml: |
+        # Anchore Service Configuration File, mounted from a configmap
+        #
+        service_dir: ${ANCHORE_SERVICE_DIR}
+        tmp_dir: ${ANCHORE_TMP_DIR}
+        log_level: ${ANCHORE_LOG_LEVEL} # Deprecated - prefer use of logging.log_level
+
+        logging:
+          colored_logging: false
+          exception_backtrace_logging: false
+          exception_diagnose_logging: false
+          file_retention_rule: 10
+          file_rotation_rule: 10 MB
+          log_level: <ALLOW_API_CONFIGURATION>
+          server_access_logging: true
+          server_log_level: info
+          server_response_debug_logging: false
+          structured_logging: false
+
+        server:
+          max_connection_backlog: 2048
+          max_wsgi_middleware_worker_count: 50
+          max_wsgi_middleware_worker_queue_size: 100
+          timeout_graceful_shutdown: false
+          timeout_keep_alive: 5
+
+        allow_awsecr_iam_auto: ${ANCHORE_ALLOW_ECR_IAM_AUTO}
+        host_id: "${ANCHORE_HOST_ID}"
+        internal_ssl_verify: ${ANCHORE_INTERNAL_SSL_VERIFY}
+        image_analyze_timeout_seconds: ${ANCHORE_IMAGE_ANALYZE_TIMEOUT_SECONDS}
+
+        global_client_connect_timeout: ${ANCHORE_GLOBAL_CLIENT_CONNECT_TIMEOUT}
+        global_client_read_timeout: ${ANCHORE_GLOBAL_CLIENT_READ_TIMEOUT}
+        server_request_timeout_seconds: ${ANCHORE_GLOBAL_SERVER_REQUEST_TIMEOUT_SEC}
+
+        license_file: ${ANCHORE_LICENSE_FILE}
+        auto_restart_services: false
+
+        max_source_import_size_mb: ${ANCHORE_MAX_IMPORT_SOURCE_SIZE_MB}
+        max_import_content_size_mb: ${ANCHORE_MAX_IMPORT_CONTENT_SIZE_MB}
+
+        max_compressed_image_size_mb: ${ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB}
+
+        audit:
+          enabled: true
+          mode: log
+          verbs:
+            - post
+            - put
+            - delete
+            - patch
+          resource_uris:
+            - "/accounts"
+            - "/accounts/{account_name}"
+            - "/accounts/{account_name}/state"
+            - "/accounts/{account_name}/users"
+            - "/accounts/{account_name}/users/{username}"
+            - "/accounts/{account_name}/users/{username}/api-keys"
+            - "/accounts/{account_name}/users/{username}/api-keys/{key_name}"
+            - "/accounts/{account_name}/users/{username}/credentials"
+            - "/rbac-manager/roles"
+            - "/rbac-manager/roles/{role_name}/members"
+            - "/rbac-manager/saml/idps"
+            - "/rbac-manager/saml/idps/{name}"
+            - "/rbac-manager/saml/idps/{name}/user-group-mappings"
+            - "/system/user-groups"
+            - "/system/user-groups/{group_uuid}"
+            - "/system/user-groups/{group_uuid}/roles"
+            - "/system/user-groups/{group_uuid}/users"
+            - "/user/api-keys"
+            - "/user/api-keys/{key_name}"
+            - "/user/credentials"
+
+        metrics:
+          enabled: ${ANCHORE_ENABLE_METRICS}
+          auth_disabled: ${ANCHORE_DISABLE_METRICS_AUTH}
+
+        webhooks:
+          {}
+
+        default_admin_password: "${ANCHORE_ADMIN_PASSWORD}"
+        default_admin_email: ${ANCHORE_ADMIN_EMAIL}
+
+        configuration:
+          api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}
+
+        keys:
+          secret: "${ANCHORE_SAML_SECRET}"
+          public_key_path: ${ANCHORE_AUTH_PRIVKEY}
+          private_key_path: ${ANCHORE_AUTH_PUBKEY}
+
+        user_authentication:
+          oauth:
+            enabled: ${ANCHORE_OAUTH_ENABLED}
+            default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}
+            refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}
+          hashed_passwords: ${ANCHORE_AUTH_ENABLE_HASHED_PASSWORDS}
+          sso_require_existing_users: ${ANCHORE_SSO_REQUIRES_EXISTING_USERS}
+          allow_api_keys_for_saml_users: false
+          max_api_key_age_days: 365
+          max_api_keys_per_user: 100
+          remove_deleted_user_api_keys_older_than_days: 365
+          disallow_native_users: false
+          log_saml_assertions: false
+        credentials:
+          database:
+            user: "${ANCHORE_DB_USER}"
+            password: "${ANCHORE_DB_PASSWORD}"
+            host: "${ANCHORE_DB_HOST}"
+            port: "${ANCHORE_DB_PORT}"
+            name: "${ANCHORE_DB_NAME}"
+            db_connect_args:
+              timeout: ${ANCHORE_DB_TIMEOUT}
+              ssl: ${ANCHORE_DB_SSL}
+            db_pool_size: ${ANCHORE_DB_POOL_SIZE}
+            db_pool_max_overflow: ${ANCHORE_DB_POOL_MAX_OVERFLOW}
+
+        account_gc:
+          max_resource_gc_chunk: 4096
+          max_deletion_threads: 4
+
+        services:
+          apiext:
+            enabled: true
+            image_content:
+              remove_license_content_from_sbom_return: false
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          analyzer:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            cycle_timer_seconds: 1
+            cycle_timers:
+              image_analyzer: 1
+            analyzer_driver: 'nodocker'
+            layer_cache_enable: ${ANCHORE_LAYER_CACHE_ENABLED}
+            layer_cache_max_gigabytes: ${ANCHORE_LAYER_CACHE_SIZE_GB}
+            enable_hints: ${ANCHORE_HINTS_ENABLED}
+            enable_owned_package_filtering: ${ANCHORE_OWNED_PACKAGE_FILTERING_ENABLED}
+            keep_image_analysis_tmpfiles: ${ANCHORE_KEEP_IMAGE_ANALYSIS_TMPFILES}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          catalog:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            account_prometheus_metrics: <ALLOW_API_CONFIGURATION>
+            cycle_timer_seconds: 1
+            cycle_timers:
+              analyzer_queue: 1
+              archive_tasks: 43200
+              artifact_lifecycle_policy_tasks: 43200
+              events_gc: 43200
+              image_gc: 60
+              image_watcher: 3600
+              k8s_image_watcher: 150
+              notifications: 30
+              policy_bundle_sync: 300
+              policy_eval: 3600
+              repo_watcher: 60
+              resource_metrics: 60
+              service_watcher: 15
+              vulnerability_scan: 14400
+            event_log:
+              max_retention_age_days: 180
+              notification:
+                enabled: false
+                level:
+                - error
+            runtime_inventory:
+              inventory_ttl_days: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_TTL_DAYS}
+              inventory_ingest_overwrite: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_INGEST_OVERWRITE}
+            integrations:
+              integration_health_report_ttl_days: ${ANCHORE_ENTERPRISE_INTEGRATION_HEALTH_REPORTS_TTL_DAYS}
+            image_gc:
+              max_worker_threads: ${ANCHORE_CATALOG_IMAGE_GC_WORKERS}
+            runtime_compliance:
+              object_store_bucket: "runtime_compliance_check"
+            down_analyzer_task_requeue: ${ANCHORE_ANALYZER_TASK_REQUEUE}
+            import_operation_expiration_days: ${ANCHORE_IMPORT_OPERATION_EXPIRATION_DAYS}
+            sbom_vuln_scan:
+              auto_scale: true
+              batch_size: 1
+              pool_size: 1
+            analysis_archive:
+              {}
+            object_store:
+              compression:
+                enabled: true
+                min_size_kbytes: 100
+              storage_driver:
+                config: {}
+                name: db
+              verify_content_digests: true
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          simplequeue:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          policy_engine:
+            enabled: true
+            require_auth: true
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            policy_evaluation_cache_ttl: ${ANCHORE_POLICY_EVAL_CACHE_TTL_SECONDS}
+            enable_package_db_load: ${ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD}
+            enable_user_base_image: true
+            vulnerabilities:
+              sync:
+                enabled: true
+                ssl_verify: ${ANCHORE_FEEDS_SSL_VERIFY}
+                connection_timeout_seconds: 3
+                read_timeout_seconds: 60
+                data:
+                  grypedb:
+                    enabled: true
+              matching:
+                exclude:
+                  providers: []
+                  package_types: []
+                default:
+                  search:
+                    by_cpe:
+                      enabled: ${ANCHORE_VULN_MATCHING_DEFAULT_SEARCH_BY_CPE_ENABLED}
+                ecosystem_specific:
+                  dotnet:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_DOTNET_SEARCH_BY_CPE_ENABLED}
+                  golang:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_GOLANG_SEARCH_BY_CPE_ENABLED}
+                  java:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVA_SEARCH_BY_CPE_ENABLED}
+                  javascript:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVASCRIPT_SEARCH_BY_CPE_ENABLED}
+                  python:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_PYTHON_SEARCH_BY_CPE_ENABLED}
+                  ruby:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_RUBY_SEARCH_BY_CPE_ENABLED}
+                  stock:
+                    search:
+                      by_cpe:
+                        # Disabling search by CPE for the stock matcher will entirely disable binary-only matches and is not advised
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_STOCK_SEARCH_BY_CPE_ENABLED}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          reports:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            enable_graphiql: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_GRAPHIQL}
+            cycle_timers:
+              reports_scheduled_queries: 600
+            max_async_execution_threads: ${ANCHORE_ENTERPRISE_REPORTS_MAX_ASYNC_EXECUTION_THREADS}
+            async_execution_timeout: ${ANCHORE_ENTERPRISE_REPORTS_ASYNC_EXECUTION_TIMEOUT}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+            use_volume: false
+
+          reports_worker:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            enable_data_ingress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_INGRESS}
+            enable_data_egress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_EGRESS}
+            data_egress_window: ${ANCHORE_ENTERPRISE_REPORTS_DATA_EGRESS_WINDOW}
+            data_refresh_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_REFRESH_MAX_WORKERS}
+            data_load_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_LOAD_MAX_WORKERS}
+            cycle_timers:
+              reports_extended_runtime_vuln_load: 1800
+              reports_image_egress: 600
+              reports_image_load: 600
+              reports_image_refresh: 7200
+              reports_metrics: 3600
+              reports_runtime_inventory_load: 600
+              reports_tag_egress: 600
+              reports_tag_load: 600
+              reports_tag_refresh: 7200
+            runtime_report_generation:
+              use_legacy_loaders_and_queries: false
+              inventory_images_by_vulnerability: true
+              vulnerabilities_by_k8s_namespace: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_NAMESPACE}
+              vulnerabilities_by_k8s_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_CONTAINER}
+              vulnerabilities_by_ecs_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_ECS_CONTAINER}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          notifications:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            cycle_timers:
+              notifications: 30
+            ui_url: ${ANCHORE_ENTERPRISE_UI_URL}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          data_syncer:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: 0.0.0.0
+            port: ${ANCHORE_PORT}
+            auto_sync_enabled: ${ANCHORE_DATA_SYNC_AUTO_SYNC_ENABLED}
+            upload_dir: /analysis_scratch
+            datasets:
+              vulnerability_db:
+                versions: ["5"]
+              clamav_db:
+                versions: ["1"]
+              kev_db:
+                versions: ["1"]
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
     kind: ConfigMap
     metadata:
       annotations:
@@ -226,7 +592,33 @@ should render the configmaps:
   6: |
     apiVersion: v1
     data:
-      config-ui.yaml: "# Anchore UI configuration\nreports_uri: 'http://test-release-enterprise-api:8228/v2'\nnotifications_uri: 'http://test-release-enterprise-api:8228/v2'\nenterprise_uri: 'http://test-release-enterprise-api:8228/v2'\n# redis_uri: overridden in deployment using the `ANCHORE_REDIS_URI` environment variable\n# appdb_uri: overridden in deployment using the `ANCHORE_APPDB_URI` environment variable\nlicense_path: '/home/anchore/'\nenable_ssl: false\nenable_proxy: false\nallow_shared_login: true\nredis_flushdb: true\nforce_websocket: false\nauthentication_lock:\n  count: 5\n  expires: 300\nappdb_config: \n  native: true\n  pool:\n    acquire: 30000\n    idle: 10000\n    max: 10\n    min: 0\nlog_level: 'http'\nenrich_inventory_view: true\nenable_prometheus_metrics: false\nsso_auth_only: false\n"
+      config-ui.yaml: |
+        # Anchore UI configuration
+        reports_uri: 'http://test-release-enterprise-api:8228/v2'
+        notifications_uri: 'http://test-release-enterprise-api:8228/v2'
+        enterprise_uri: 'http://test-release-enterprise-api:8228/v2'
+        # redis_uri: overridden in deployment using the `ANCHORE_REDIS_URI` environment variable
+        # appdb_uri: overridden in deployment using the `ANCHORE_APPDB_URI` environment variable
+        license_path: '/home/anchore/'
+        enable_ssl: false
+        enable_proxy: false
+        allow_shared_login: true
+        redis_flushdb: true
+        force_websocket: false
+        authentication_lock:
+          count: 5
+          expires: 300
+        appdb_config:
+          native: true
+          pool:
+            acquire: 30000
+            idle: 10000
+            max: 10
+            min: 0
+        log_level: 'http'
+        enrich_inventory_view: true
+        enable_prometheus_metrics: false
+        sso_auth_only: false
     kind: ConfigMap
     metadata:
       annotations:

--- a/stable/enterprise/tests/__snapshot__/osaa_configmap_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/osaa_configmap_test.yaml.snap
@@ -2,7 +2,373 @@ should render the configmaps for osaa migration if enabled:
   1: |
     apiVersion: v1
     data:
-      config.yaml: "# Anchore Service Configuration File, mounted from a configmap\n#\nservice_dir: ${ANCHORE_SERVICE_DIR}\ntmp_dir: ${ANCHORE_TMP_DIR}\nlog_level: ${ANCHORE_LOG_LEVEL} # Deprecated - prefer use of logging.log_level\n\nlogging:\n  colored_logging: false\n  exception_backtrace_logging: false\n  exception_diagnose_logging: false\n  file_retention_rule: 10\n  file_rotation_rule: 10 MB\n  log_level: <ALLOW_API_CONFIGURATION>\n  server_access_logging: true\n  server_log_level: info\n  server_response_debug_logging: false\n  structured_logging: false\n\nserver:\n  max_connection_backlog: 2048\n  max_wsgi_middleware_worker_count: 50\n  max_wsgi_middleware_worker_queue_size: 100\n  timeout_graceful_shutdown: false\n  timeout_keep_alive: 5\n\nallow_awsecr_iam_auto: ${ANCHORE_ALLOW_ECR_IAM_AUTO}\nhost_id: \"${ANCHORE_HOST_ID}\"\ninternal_ssl_verify: ${ANCHORE_INTERNAL_SSL_VERIFY}\nimage_analyze_timeout_seconds: ${ANCHORE_IMAGE_ANALYZE_TIMEOUT_SECONDS}\n\nglobal_client_connect_timeout: ${ANCHORE_GLOBAL_CLIENT_CONNECT_TIMEOUT}\nglobal_client_read_timeout: ${ANCHORE_GLOBAL_CLIENT_READ_TIMEOUT}\nserver_request_timeout_seconds: ${ANCHORE_GLOBAL_SERVER_REQUEST_TIMEOUT_SEC}\n\nlicense_file: ${ANCHORE_LICENSE_FILE}\nauto_restart_services: false\n\nmax_source_import_size_mb: ${ANCHORE_MAX_IMPORT_SOURCE_SIZE_MB}\nmax_import_content_size_mb: ${ANCHORE_MAX_IMPORT_CONTENT_SIZE_MB}\n\nmax_compressed_image_size_mb: ${ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB}\n\naudit:\n  enabled: true\n  mode: log\n  verbs:\n    - post\n    - put\n    - delete\n    - patch\n  resource_uris:\n    - \"/accounts\"\n    - \"/accounts/{account_name}\"\n    - \"/accounts/{account_name}/state\"\n    - \"/accounts/{account_name}/users\"\n    - \"/accounts/{account_name}/users/{username}\"\n    - \"/accounts/{account_name}/users/{username}/api-keys\"\n    - \"/accounts/{account_name}/users/{username}/api-keys/{key_name}\"\n    - \"/accounts/{account_name}/users/{username}/credentials\"\n    - \"/rbac-manager/roles\"\n    - \"/rbac-manager/roles/{role_name}/members\"\n    - \"/rbac-manager/saml/idps\"\n    - \"/rbac-manager/saml/idps/{name}\"\n    - \"/rbac-manager/saml/idps/{name}/user-group-mappings\"\n    - \"/system/user-groups\"\n    - \"/system/user-groups/{group_uuid}\"\n    - \"/system/user-groups/{group_uuid}/roles\"\n    - \"/system/user-groups/{group_uuid}/users\"\n    - \"/user/api-keys\"\n    - \"/user/api-keys/{key_name}\"\n    - \"/user/credentials\"\n\nmetrics:\n  enabled: ${ANCHORE_ENABLE_METRICS}\n  auth_disabled: ${ANCHORE_DISABLE_METRICS_AUTH}\n\nwebhooks:\n  {}\n\ndefault_admin_password: \"${ANCHORE_ADMIN_PASSWORD}\"\ndefault_admin_email: ${ANCHORE_ADMIN_EMAIL}\n\nconfiguration: \n  api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}\n\nkeys:\n  secret: \"${ANCHORE_SAML_SECRET}\"\n  public_key_path: ${ANCHORE_AUTH_PRIVKEY}\n  private_key_path: ${ANCHORE_AUTH_PUBKEY}\n\nuser_authentication:\n  oauth:\n    enabled: ${ANCHORE_OAUTH_ENABLED}\n    default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}\n    refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}\n  hashed_passwords: ${ANCHORE_AUTH_ENABLE_HASHED_PASSWORDS}\n  sso_require_existing_users: ${ANCHORE_SSO_REQUIRES_EXISTING_USERS}\n  allow_api_keys_for_saml_users: false\n  max_api_key_age_days: 365\n  max_api_keys_per_user: 100\n  remove_deleted_user_api_keys_older_than_days: 365\n  disallow_native_users: false\n  log_saml_assertions: false\ncredentials:\n  database:\n    user: \"${ANCHORE_DB_USER}\"\n    password: \"${ANCHORE_DB_PASSWORD}\"\n    host: \"${ANCHORE_DB_HOST}\"\n    port: \"${ANCHORE_DB_PORT}\"\n    name: \"${ANCHORE_DB_NAME}\"\n    db_connect_args:\n      timeout: ${ANCHORE_DB_TIMEOUT}\n      ssl: ${ANCHORE_DB_SSL}\n    db_pool_size: ${ANCHORE_DB_POOL_SIZE}\n    db_pool_max_overflow: ${ANCHORE_DB_POOL_MAX_OVERFLOW}\n\naccount_gc:\n  max_resource_gc_chunk: 4096\n  max_deletion_threads: 4\n\nservices:\n  apiext:\n    enabled: true\n    image_content:\n      remove_license_content_from_sbom_return: <ALLOW_API_CONFIGURATION>\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  analyzer:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    cycle_timer_seconds: 1\n    cycle_timers:\n      image_analyzer: 1\n    analyzer_driver: 'nodocker'\n    layer_cache_enable: ${ANCHORE_LAYER_CACHE_ENABLED}\n    layer_cache_max_gigabytes: ${ANCHORE_LAYER_CACHE_SIZE_GB}\n    enable_hints: ${ANCHORE_HINTS_ENABLED}\n    enable_owned_package_filtering: ${ANCHORE_OWNED_PACKAGE_FILTERING_ENABLED}\n    keep_image_analysis_tmpfiles: ${ANCHORE_KEEP_IMAGE_ANALYSIS_TMPFILES}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  catalog:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    account_prometheus_metrics: <ALLOW_API_CONFIGURATION>\n    cycle_timer_seconds: 1\n    cycle_timers:\n      analyzer_queue: 1\n      archive_tasks: 43200\n      artifact_lifecycle_policy_tasks: 43200\n      events_gc: 43200\n      image_gc: 60\n      image_watcher: 3600\n      k8s_image_watcher: 150\n      notifications: 30\n      policy_bundle_sync: 300\n      policy_eval: 3600\n      repo_watcher: 60\n      resource_metrics: 60\n      service_watcher: 15\n      vulnerability_scan: 14400\n    event_log:\n      max_retention_age_days: 180\n      notification:\n        enabled: false\n        level:\n        - error\n    runtime_inventory:\n      inventory_ttl_days: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_TTL_DAYS}\n      inventory_ingest_overwrite: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_INGEST_OVERWRITE}\n    integrations:\n      integration_health_report_ttl_days: ${ANCHORE_ENTERPRISE_INTEGRATION_HEALTH_REPORTS_TTL_DAYS}\n    image_gc:\n      max_worker_threads: ${ANCHORE_CATALOG_IMAGE_GC_WORKERS}\n    runtime_compliance:\n      object_store_bucket: \"runtime_compliance_check\"\n    down_analyzer_task_requeue: ${ANCHORE_ANALYZER_TASK_REQUEUE}\n    import_operation_expiration_days: ${ANCHORE_IMPORT_OPERATION_EXPIRATION_DAYS}\n    sbom_vuln_scan:\n      auto_scale: true\n      batch_size: 1\n      pool_size: 1\n    analysis_archive:\n      {}\n    object_store:\n      compression:\n        enabled: true\n        min_size_kbytes: 100\n      storage_driver:\n        config: {}\n        name: db\n      verify_content_digests: true\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  simplequeue:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  policy_engine:\n    enabled: true\n    require_auth: true\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    policy_evaluation_cache_ttl: ${ANCHORE_POLICY_EVAL_CACHE_TTL_SECONDS}\n    enable_package_db_load: ${ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD}\n    enable_user_base_image: true\n    vulnerabilities:\n      sync:\n        enabled: true\n        ssl_verify: ${ANCHORE_FEEDS_SSL_VERIFY}\n        connection_timeout_seconds: 3\n        read_timeout_seconds: 60\n        data:\n          grypedb:\n            enabled: true\n      matching:\n        exclude:\n          providers: []\n          package_types: []\n        default:\n          search:\n            by_cpe:\n              enabled: ${ANCHORE_VULN_MATCHING_DEFAULT_SEARCH_BY_CPE_ENABLED}\n        ecosystem_specific:\n          dotnet:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_DOTNET_SEARCH_BY_CPE_ENABLED}\n          golang:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_GOLANG_SEARCH_BY_CPE_ENABLED}\n          java:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVA_SEARCH_BY_CPE_ENABLED}\n          javascript:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVASCRIPT_SEARCH_BY_CPE_ENABLED}\n          python:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_PYTHON_SEARCH_BY_CPE_ENABLED}\n          ruby:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_RUBY_SEARCH_BY_CPE_ENABLED}\n          stock:\n            search:\n              by_cpe:\n                # Disabling search by CPE for the stock matcher will entirely disable binary-only matches and is not advised\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_STOCK_SEARCH_BY_CPE_ENABLED}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  reports:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    enable_graphiql: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_GRAPHIQL}\n    cycle_timers:\n      reports_scheduled_queries: 600\n    max_async_execution_threads: ${ANCHORE_ENTERPRISE_REPORTS_MAX_ASYNC_EXECUTION_THREADS}\n    async_execution_timeout: ${ANCHORE_ENTERPRISE_REPORTS_ASYNC_EXECUTION_TIMEOUT}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n    use_volume: false\n\n  reports_worker:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    enable_data_ingress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_INGRESS}\n    enable_data_egress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_EGRESS}\n    data_egress_window: ${ANCHORE_ENTERPRISE_REPORTS_DATA_EGRESS_WINDOW}\n    data_refresh_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_REFRESH_MAX_WORKERS}\n    data_load_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_LOAD_MAX_WORKERS}\n    cycle_timers:\n      reports_extended_runtime_vuln_load: 1800\n      reports_image_egress: 600\n      reports_image_load: 600\n      reports_image_refresh: 7200\n      reports_metrics: 3600\n      reports_runtime_inventory_load: 600\n      reports_tag_egress: 600\n      reports_tag_load: 600\n      reports_tag_refresh: 7200\n    runtime_report_generation:\n      use_legacy_loaders_and_queries: false\n      inventory_images_by_vulnerability: true\n      vulnerabilities_by_k8s_namespace: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_NAMESPACE}\n      vulnerabilities_by_k8s_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_CONTAINER}\n      vulnerabilities_by_ecs_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_ECS_CONTAINER}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  notifications:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    cycle_timers:\n      notifications: 30\n    ui_url: ${ANCHORE_ENTERPRISE_UI_URL}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  data_syncer:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: 0.0.0.0\n    port: ${ANCHORE_PORT}\n    auto_sync_enabled: ${ANCHORE_DATA_SYNC_AUTO_SYNC_ENABLED}\n    upload_dir: /analysis_scratch\n    datasets:\n      vulnerability_db:\n        versions: [\"5\"]\n      clamav_db:\n        versions: [\"1\"]\n      kev_db:\n        versions: [\"1\"]\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n"
+      config.yaml: |
+        # Anchore Service Configuration File, mounted from a configmap
+        #
+        service_dir: ${ANCHORE_SERVICE_DIR}
+        tmp_dir: ${ANCHORE_TMP_DIR}
+        log_level: ${ANCHORE_LOG_LEVEL} # Deprecated - prefer use of logging.log_level
+
+        logging:
+          colored_logging: false
+          exception_backtrace_logging: false
+          exception_diagnose_logging: false
+          file_retention_rule: 10
+          file_rotation_rule: 10 MB
+          log_level: <ALLOW_API_CONFIGURATION>
+          server_access_logging: true
+          server_log_level: info
+          server_response_debug_logging: false
+          structured_logging: false
+
+        server:
+          max_connection_backlog: 2048
+          max_wsgi_middleware_worker_count: 50
+          max_wsgi_middleware_worker_queue_size: 100
+          timeout_graceful_shutdown: false
+          timeout_keep_alive: 5
+
+        allow_awsecr_iam_auto: ${ANCHORE_ALLOW_ECR_IAM_AUTO}
+        host_id: "${ANCHORE_HOST_ID}"
+        internal_ssl_verify: ${ANCHORE_INTERNAL_SSL_VERIFY}
+        image_analyze_timeout_seconds: ${ANCHORE_IMAGE_ANALYZE_TIMEOUT_SECONDS}
+
+        global_client_connect_timeout: ${ANCHORE_GLOBAL_CLIENT_CONNECT_TIMEOUT}
+        global_client_read_timeout: ${ANCHORE_GLOBAL_CLIENT_READ_TIMEOUT}
+        server_request_timeout_seconds: ${ANCHORE_GLOBAL_SERVER_REQUEST_TIMEOUT_SEC}
+
+        license_file: ${ANCHORE_LICENSE_FILE}
+        auto_restart_services: false
+
+        max_source_import_size_mb: ${ANCHORE_MAX_IMPORT_SOURCE_SIZE_MB}
+        max_import_content_size_mb: ${ANCHORE_MAX_IMPORT_CONTENT_SIZE_MB}
+
+        max_compressed_image_size_mb: ${ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB}
+
+        audit:
+          enabled: true
+          mode: log
+          verbs:
+            - post
+            - put
+            - delete
+            - patch
+          resource_uris:
+            - "/accounts"
+            - "/accounts/{account_name}"
+            - "/accounts/{account_name}/state"
+            - "/accounts/{account_name}/users"
+            - "/accounts/{account_name}/users/{username}"
+            - "/accounts/{account_name}/users/{username}/api-keys"
+            - "/accounts/{account_name}/users/{username}/api-keys/{key_name}"
+            - "/accounts/{account_name}/users/{username}/credentials"
+            - "/rbac-manager/roles"
+            - "/rbac-manager/roles/{role_name}/members"
+            - "/rbac-manager/saml/idps"
+            - "/rbac-manager/saml/idps/{name}"
+            - "/rbac-manager/saml/idps/{name}/user-group-mappings"
+            - "/system/user-groups"
+            - "/system/user-groups/{group_uuid}"
+            - "/system/user-groups/{group_uuid}/roles"
+            - "/system/user-groups/{group_uuid}/users"
+            - "/user/api-keys"
+            - "/user/api-keys/{key_name}"
+            - "/user/credentials"
+
+        metrics:
+          enabled: ${ANCHORE_ENABLE_METRICS}
+          auth_disabled: ${ANCHORE_DISABLE_METRICS_AUTH}
+
+        webhooks:
+          {}
+
+        default_admin_password: "${ANCHORE_ADMIN_PASSWORD}"
+        default_admin_email: ${ANCHORE_ADMIN_EMAIL}
+
+        configuration:
+          api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}
+
+        keys:
+          secret: "${ANCHORE_SAML_SECRET}"
+          public_key_path: ${ANCHORE_AUTH_PRIVKEY}
+          private_key_path: ${ANCHORE_AUTH_PUBKEY}
+
+        user_authentication:
+          oauth:
+            enabled: ${ANCHORE_OAUTH_ENABLED}
+            default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}
+            refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}
+          hashed_passwords: ${ANCHORE_AUTH_ENABLE_HASHED_PASSWORDS}
+          sso_require_existing_users: ${ANCHORE_SSO_REQUIRES_EXISTING_USERS}
+          allow_api_keys_for_saml_users: false
+          max_api_key_age_days: 365
+          max_api_keys_per_user: 100
+          remove_deleted_user_api_keys_older_than_days: 365
+          disallow_native_users: false
+          log_saml_assertions: false
+        credentials:
+          database:
+            user: "${ANCHORE_DB_USER}"
+            password: "${ANCHORE_DB_PASSWORD}"
+            host: "${ANCHORE_DB_HOST}"
+            port: "${ANCHORE_DB_PORT}"
+            name: "${ANCHORE_DB_NAME}"
+            db_connect_args:
+              timeout: ${ANCHORE_DB_TIMEOUT}
+              ssl: ${ANCHORE_DB_SSL}
+            db_pool_size: ${ANCHORE_DB_POOL_SIZE}
+            db_pool_max_overflow: ${ANCHORE_DB_POOL_MAX_OVERFLOW}
+
+        account_gc:
+          max_resource_gc_chunk: 4096
+          max_deletion_threads: 4
+
+        services:
+          apiext:
+            enabled: true
+            image_content:
+              remove_license_content_from_sbom_return: false
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          analyzer:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            cycle_timer_seconds: 1
+            cycle_timers:
+              image_analyzer: 1
+            analyzer_driver: 'nodocker'
+            layer_cache_enable: ${ANCHORE_LAYER_CACHE_ENABLED}
+            layer_cache_max_gigabytes: ${ANCHORE_LAYER_CACHE_SIZE_GB}
+            enable_hints: ${ANCHORE_HINTS_ENABLED}
+            enable_owned_package_filtering: ${ANCHORE_OWNED_PACKAGE_FILTERING_ENABLED}
+            keep_image_analysis_tmpfiles: ${ANCHORE_KEEP_IMAGE_ANALYSIS_TMPFILES}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          catalog:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            account_prometheus_metrics: <ALLOW_API_CONFIGURATION>
+            cycle_timer_seconds: 1
+            cycle_timers:
+              analyzer_queue: 1
+              archive_tasks: 43200
+              artifact_lifecycle_policy_tasks: 43200
+              events_gc: 43200
+              image_gc: 60
+              image_watcher: 3600
+              k8s_image_watcher: 150
+              notifications: 30
+              policy_bundle_sync: 300
+              policy_eval: 3600
+              repo_watcher: 60
+              resource_metrics: 60
+              service_watcher: 15
+              vulnerability_scan: 14400
+            event_log:
+              max_retention_age_days: 180
+              notification:
+                enabled: false
+                level:
+                - error
+            runtime_inventory:
+              inventory_ttl_days: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_TTL_DAYS}
+              inventory_ingest_overwrite: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_INGEST_OVERWRITE}
+            integrations:
+              integration_health_report_ttl_days: ${ANCHORE_ENTERPRISE_INTEGRATION_HEALTH_REPORTS_TTL_DAYS}
+            image_gc:
+              max_worker_threads: ${ANCHORE_CATALOG_IMAGE_GC_WORKERS}
+            runtime_compliance:
+              object_store_bucket: "runtime_compliance_check"
+            down_analyzer_task_requeue: ${ANCHORE_ANALYZER_TASK_REQUEUE}
+            import_operation_expiration_days: ${ANCHORE_IMPORT_OPERATION_EXPIRATION_DAYS}
+            sbom_vuln_scan:
+              auto_scale: true
+              batch_size: 1
+              pool_size: 1
+            analysis_archive:
+              {}
+            object_store:
+              compression:
+                enabled: true
+                min_size_kbytes: 100
+              storage_driver:
+                config: {}
+                name: db
+              verify_content_digests: true
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          simplequeue:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          policy_engine:
+            enabled: true
+            require_auth: true
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            policy_evaluation_cache_ttl: ${ANCHORE_POLICY_EVAL_CACHE_TTL_SECONDS}
+            enable_package_db_load: ${ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD}
+            enable_user_base_image: true
+            vulnerabilities:
+              sync:
+                enabled: true
+                ssl_verify: ${ANCHORE_FEEDS_SSL_VERIFY}
+                connection_timeout_seconds: 3
+                read_timeout_seconds: 60
+                data:
+                  grypedb:
+                    enabled: true
+              matching:
+                exclude:
+                  providers: []
+                  package_types: []
+                default:
+                  search:
+                    by_cpe:
+                      enabled: ${ANCHORE_VULN_MATCHING_DEFAULT_SEARCH_BY_CPE_ENABLED}
+                ecosystem_specific:
+                  dotnet:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_DOTNET_SEARCH_BY_CPE_ENABLED}
+                  golang:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_GOLANG_SEARCH_BY_CPE_ENABLED}
+                  java:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVA_SEARCH_BY_CPE_ENABLED}
+                  javascript:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVASCRIPT_SEARCH_BY_CPE_ENABLED}
+                  python:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_PYTHON_SEARCH_BY_CPE_ENABLED}
+                  ruby:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_RUBY_SEARCH_BY_CPE_ENABLED}
+                  stock:
+                    search:
+                      by_cpe:
+                        # Disabling search by CPE for the stock matcher will entirely disable binary-only matches and is not advised
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_STOCK_SEARCH_BY_CPE_ENABLED}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          reports:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            enable_graphiql: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_GRAPHIQL}
+            cycle_timers:
+              reports_scheduled_queries: 600
+            max_async_execution_threads: ${ANCHORE_ENTERPRISE_REPORTS_MAX_ASYNC_EXECUTION_THREADS}
+            async_execution_timeout: ${ANCHORE_ENTERPRISE_REPORTS_ASYNC_EXECUTION_TIMEOUT}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+            use_volume: false
+
+          reports_worker:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            enable_data_ingress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_INGRESS}
+            enable_data_egress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_EGRESS}
+            data_egress_window: ${ANCHORE_ENTERPRISE_REPORTS_DATA_EGRESS_WINDOW}
+            data_refresh_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_REFRESH_MAX_WORKERS}
+            data_load_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_LOAD_MAX_WORKERS}
+            cycle_timers:
+              reports_extended_runtime_vuln_load: 1800
+              reports_image_egress: 600
+              reports_image_load: 600
+              reports_image_refresh: 7200
+              reports_metrics: 3600
+              reports_runtime_inventory_load: 600
+              reports_tag_egress: 600
+              reports_tag_load: 600
+              reports_tag_refresh: 7200
+            runtime_report_generation:
+              use_legacy_loaders_and_queries: false
+              inventory_images_by_vulnerability: true
+              vulnerabilities_by_k8s_namespace: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_NAMESPACE}
+              vulnerabilities_by_k8s_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_CONTAINER}
+              vulnerabilities_by_ecs_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_ECS_CONTAINER}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          notifications:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            cycle_timers:
+              notifications: 30
+            ui_url: ${ANCHORE_ENTERPRISE_UI_URL}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          data_syncer:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: 0.0.0.0
+            port: ${ANCHORE_PORT}
+            auto_sync_enabled: ${ANCHORE_DATA_SYNC_AUTO_SYNC_ENABLED}
+            upload_dir: /analysis_scratch
+            datasets:
+              vulnerability_db:
+                versions: ["5"]
+              clamav_db:
+                versions: ["1"]
+              kev_db:
+                versions: ["1"]
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
     kind: ConfigMap
     metadata:
       annotations:
@@ -22,7 +388,384 @@ should render the configmaps for osaa migration if enabled:
   2: |
     apiVersion: v1
     data:
-      config.yaml: "# Anchore Object Store and Analysis Archive Migration configuration file, mounted from a configmap\n#\nservice_dir: ${ANCHORE_SERVICE_DIR}\ntmp_dir: ${ANCHORE_TMP_DIR}\nlog_level: ${ANCHORE_LOG_LEVEL} # Deprecated - prefer use of logging.log_level\n\nlogging:\n  colored_logging: false\n  exception_backtrace_logging: false\n  exception_diagnose_logging: false\n  file_retention_rule: 10\n  file_rotation_rule: 10 MB\n  log_level: <ALLOW_API_CONFIGURATION>\n  server_access_logging: true\n  server_log_level: info\n  server_response_debug_logging: false\n  structured_logging: false\n\nserver:\n  max_connection_backlog: 2048\n  max_wsgi_middleware_worker_count: 50\n  max_wsgi_middleware_worker_queue_size: 100\n  timeout_graceful_shutdown: false\n  timeout_keep_alive: 5\n\nallow_awsecr_iam_auto: ${ANCHORE_ALLOW_ECR_IAM_AUTO}\nhost_id: \"${ANCHORE_HOST_ID}\"\ninternal_ssl_verify: ${ANCHORE_INTERNAL_SSL_VERIFY}\nimage_analyze_timeout_seconds: ${ANCHORE_IMAGE_ANALYZE_TIMEOUT_SECONDS}\n\nglobal_client_connect_timeout: ${ANCHORE_GLOBAL_CLIENT_CONNECT_TIMEOUT}\nglobal_client_read_timeout: ${ANCHORE_GLOBAL_CLIENT_READ_TIMEOUT}\nserver_request_timeout_seconds: ${ANCHORE_GLOBAL_SERVER_REQUEST_TIMEOUT_SEC}\n\nlicense_file: ${ANCHORE_LICENSE_FILE}\nauto_restart_services: false\n\nmax_source_import_size_mb: ${ANCHORE_MAX_IMPORT_SOURCE_SIZE_MB}\nmax_import_content_size_mb: ${ANCHORE_MAX_IMPORT_CONTENT_SIZE_MB}\n\nmax_compressed_image_size_mb: ${ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB}\n\naudit:\n  enabled: true\n  mode: log\n  verbs:\n    - post\n    - put\n    - delete\n    - patch\n  resource_uris:\n    - \"/accounts\"\n    - \"/accounts/{account_name}\"\n    - \"/accounts/{account_name}/state\"\n    - \"/accounts/{account_name}/users\"\n    - \"/accounts/{account_name}/users/{username}\"\n    - \"/accounts/{account_name}/users/{username}/api-keys\"\n    - \"/accounts/{account_name}/users/{username}/api-keys/{key_name}\"\n    - \"/accounts/{account_name}/users/{username}/credentials\"\n    - \"/rbac-manager/roles\"\n    - \"/rbac-manager/roles/{role_name}/members\"\n    - \"/rbac-manager/saml/idps\"\n    - \"/rbac-manager/saml/idps/{name}\"\n    - \"/rbac-manager/saml/idps/{name}/user-group-mappings\"\n    - \"/system/user-groups\"\n    - \"/system/user-groups/{group_uuid}\"\n    - \"/system/user-groups/{group_uuid}/roles\"\n    - \"/system/user-groups/{group_uuid}/users\"\n    - \"/user/api-keys\"\n    - \"/user/api-keys/{key_name}\"\n    - \"/user/credentials\"\n\nmetrics:\n  enabled: ${ANCHORE_ENABLE_METRICS}\n  auth_disabled: ${ANCHORE_DISABLE_METRICS_AUTH}\n\nwebhooks:\n  {}\n\ndefault_admin_password: \"${ANCHORE_ADMIN_PASSWORD}\"\ndefault_admin_email: ${ANCHORE_ADMIN_EMAIL}\n\nconfiguration: \n  api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}\n\nkeys:\n  secret: \"${ANCHORE_SAML_SECRET}\"\n  public_key_path: ${ANCHORE_AUTH_PRIVKEY}\n  private_key_path: ${ANCHORE_AUTH_PUBKEY}\n\nuser_authentication:\n  oauth:\n    enabled: ${ANCHORE_OAUTH_ENABLED}\n    default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}\n    refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}\n  hashed_passwords: ${ANCHORE_AUTH_ENABLE_HASHED_PASSWORDS}\n  sso_require_existing_users: ${ANCHORE_SSO_REQUIRES_EXISTING_USERS}\n  allow_api_keys_for_saml_users: false\n  max_api_key_age_days: 365\n  max_api_keys_per_user: 100\n  remove_deleted_user_api_keys_older_than_days: 365\n  disallow_native_users: false\n  log_saml_assertions: false\ncredentials:\n  database:\n    user: \"${ANCHORE_DB_USER}\"\n    password: \"${ANCHORE_DB_PASSWORD}\"\n    host: \"${ANCHORE_DB_HOST}\"\n    port: \"${ANCHORE_DB_PORT}\"\n    name: \"${ANCHORE_DB_NAME}\"\n    db_connect_args:\n      timeout: ${ANCHORE_DB_TIMEOUT}\n      ssl: ${ANCHORE_DB_SSL}\n    db_pool_size: ${ANCHORE_DB_POOL_SIZE}\n    db_pool_max_overflow: ${ANCHORE_DB_POOL_MAX_OVERFLOW}\n\naccount_gc:\n  max_resource_gc_chunk: 4096\n  max_deletion_threads: 4\n\nservices:\n  apiext:\n    enabled: true\n    image_content:\n      remove_license_content_from_sbom_return: <ALLOW_API_CONFIGURATION>\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  analyzer:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    cycle_timer_seconds: 1\n    cycle_timers:\n      image_analyzer: 1\n    analyzer_driver: 'nodocker'\n    layer_cache_enable: ${ANCHORE_LAYER_CACHE_ENABLED}\n    layer_cache_max_gigabytes: ${ANCHORE_LAYER_CACHE_SIZE_GB}\n    enable_hints: ${ANCHORE_HINTS_ENABLED}\n    enable_owned_package_filtering: ${ANCHORE_OWNED_PACKAGE_FILTERING_ENABLED}\n    keep_image_analysis_tmpfiles: ${ANCHORE_KEEP_IMAGE_ANALYSIS_TMPFILES}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  catalog:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    account_prometheus_metrics: <ALLOW_API_CONFIGURATION>\n    cycle_timer_seconds: 1\n    cycle_timers:\n      analyzer_queue: 1\n      archive_tasks: 43200\n      artifact_lifecycle_policy_tasks: 43200\n      events_gc: 43200\n      image_gc: 60\n      image_watcher: 3600\n      k8s_image_watcher: 150\n      notifications: 30\n      policy_bundle_sync: 300\n      policy_eval: 3600\n      repo_watcher: 60\n      resource_metrics: 60\n      service_watcher: 15\n      vulnerability_scan: 14400\n    event_log:\n      max_retention_age_days: 180\n      notification:\n        enabled: false\n        level:\n        - error\n    runtime_inventory:\n      inventory_ttl_days: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_TTL_DAYS}\n      inventory_ingest_overwrite: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_INGEST_OVERWRITE}\n    integrations:\n      integration_health_report_ttl_days: ${ANCHORE_ENTERPRISE_INTEGRATION_HEALTH_REPORTS_TTL_DAYS}\n    image_gc:\n      max_worker_threads: ${ANCHORE_CATALOG_IMAGE_GC_WORKERS}\n    runtime_compliance:\n      object_store_bucket: \"runtime_compliance_check\"\n    down_analyzer_task_requeue: ${ANCHORE_ANALYZER_TASK_REQUEUE}\n    import_operation_expiration_days: ${ANCHORE_IMPORT_OPERATION_EXPIRATION_DAYS}\n    sbom_vuln_scan:\n      auto_scale: true\n      batch_size: 1\n      pool_size: 1\n    analysis_archive:\n      compression:\n        enabled: true\n        min_size_kbytes: 100\n      enabled: true\n      storage_driver:\n        config:\n          access_key: itsa\n          bucket: analysisarchive\n          region: null\n          secret_key: test\n          url: http://myminio.mynamespace.svc.cluster.local:9000\n        name: s3\n    object_store:\n      compression:\n        enabled: true\n        min_size_kbytes: 100\n      storage_driver:\n        config: {}\n        name: db\n      verify_content_digests: true\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  simplequeue:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  policy_engine:\n    enabled: true\n    require_auth: true\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    policy_evaluation_cache_ttl: ${ANCHORE_POLICY_EVAL_CACHE_TTL_SECONDS}\n    enable_package_db_load: ${ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD}\n    enable_user_base_image: true\n    vulnerabilities:\n      sync:\n        enabled: true\n        ssl_verify: ${ANCHORE_FEEDS_SSL_VERIFY}\n        connection_timeout_seconds: 3\n        read_timeout_seconds: 60\n        data:\n          grypedb:\n            enabled: true\n      matching:\n        exclude:\n          providers: []\n          package_types: []\n        default:\n          search:\n            by_cpe:\n              enabled: ${ANCHORE_VULN_MATCHING_DEFAULT_SEARCH_BY_CPE_ENABLED}\n        ecosystem_specific:\n          dotnet:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_DOTNET_SEARCH_BY_CPE_ENABLED}\n          golang:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_GOLANG_SEARCH_BY_CPE_ENABLED}\n          java:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVA_SEARCH_BY_CPE_ENABLED}\n          javascript:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVASCRIPT_SEARCH_BY_CPE_ENABLED}\n          python:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_PYTHON_SEARCH_BY_CPE_ENABLED}\n          ruby:\n            search:\n              by_cpe:\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_RUBY_SEARCH_BY_CPE_ENABLED}\n          stock:\n            search:\n              by_cpe:\n                # Disabling search by CPE for the stock matcher will entirely disable binary-only matches and is not advised\n                enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_STOCK_SEARCH_BY_CPE_ENABLED}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  reports:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    enable_graphiql: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_GRAPHIQL}\n    cycle_timers:\n      reports_scheduled_queries: 600\n    max_async_execution_threads: ${ANCHORE_ENTERPRISE_REPORTS_MAX_ASYNC_EXECUTION_THREADS}\n    async_execution_timeout: ${ANCHORE_ENTERPRISE_REPORTS_ASYNC_EXECUTION_TIMEOUT}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n    use_volume: false\n\n  reports_worker:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    enable_data_ingress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_INGRESS}\n    enable_data_egress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_EGRESS}\n    data_egress_window: ${ANCHORE_ENTERPRISE_REPORTS_DATA_EGRESS_WINDOW}\n    data_refresh_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_REFRESH_MAX_WORKERS}\n    data_load_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_LOAD_MAX_WORKERS}\n    cycle_timers:\n      reports_extended_runtime_vuln_load: 1800\n      reports_image_egress: 600\n      reports_image_load: 600\n      reports_image_refresh: 7200\n      reports_metrics: 3600\n      reports_runtime_inventory_load: 600\n      reports_tag_egress: 600\n      reports_tag_load: 600\n      reports_tag_refresh: 7200\n    runtime_report_generation:\n      use_legacy_loaders_and_queries: false\n      inventory_images_by_vulnerability: true\n      vulnerabilities_by_k8s_namespace: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_NAMESPACE}\n      vulnerabilities_by_k8s_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_CONTAINER}\n      vulnerabilities_by_ecs_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_ECS_CONTAINER}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  notifications:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: '0.0.0.0'\n    port: ${ANCHORE_PORT}\n    max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}\n    cycle_timers:\n      notifications: 30\n    ui_url: ${ANCHORE_ENTERPRISE_UI_URL}\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n\n  data_syncer:\n    enabled: true\n    require_auth: true\n    endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}\n    listen: 0.0.0.0\n    port: ${ANCHORE_PORT}\n    auto_sync_enabled: ${ANCHORE_DATA_SYNC_AUTO_SYNC_ENABLED}\n    upload_dir: /analysis_scratch\n    datasets:\n      vulnerability_db:\n        versions: [\"5\"]\n      clamav_db:\n        versions: [\"1\"]\n      kev_db:\n        versions: [\"1\"]\n    ssl_enable: ${ANCHORE_SSL_ENABLED}\n    ssl_cert: ${ANCHORE_SSL_CERT}\n    ssl_key: ${ANCHORE_SSL_KEY}\n"
+      config.yaml: |
+        # Anchore Object Store and Analysis Archive Migration configuration file, mounted from a configmap
+        #
+        service_dir: ${ANCHORE_SERVICE_DIR}
+        tmp_dir: ${ANCHORE_TMP_DIR}
+        log_level: ${ANCHORE_LOG_LEVEL} # Deprecated - prefer use of logging.log_level
+
+        logging:
+          colored_logging: false
+          exception_backtrace_logging: false
+          exception_diagnose_logging: false
+          file_retention_rule: 10
+          file_rotation_rule: 10 MB
+          log_level: <ALLOW_API_CONFIGURATION>
+          server_access_logging: true
+          server_log_level: info
+          server_response_debug_logging: false
+          structured_logging: false
+
+        server:
+          max_connection_backlog: 2048
+          max_wsgi_middleware_worker_count: 50
+          max_wsgi_middleware_worker_queue_size: 100
+          timeout_graceful_shutdown: false
+          timeout_keep_alive: 5
+
+        allow_awsecr_iam_auto: ${ANCHORE_ALLOW_ECR_IAM_AUTO}
+        host_id: "${ANCHORE_HOST_ID}"
+        internal_ssl_verify: ${ANCHORE_INTERNAL_SSL_VERIFY}
+        image_analyze_timeout_seconds: ${ANCHORE_IMAGE_ANALYZE_TIMEOUT_SECONDS}
+
+        global_client_connect_timeout: ${ANCHORE_GLOBAL_CLIENT_CONNECT_TIMEOUT}
+        global_client_read_timeout: ${ANCHORE_GLOBAL_CLIENT_READ_TIMEOUT}
+        server_request_timeout_seconds: ${ANCHORE_GLOBAL_SERVER_REQUEST_TIMEOUT_SEC}
+
+        license_file: ${ANCHORE_LICENSE_FILE}
+        auto_restart_services: false
+
+        max_source_import_size_mb: ${ANCHORE_MAX_IMPORT_SOURCE_SIZE_MB}
+        max_import_content_size_mb: ${ANCHORE_MAX_IMPORT_CONTENT_SIZE_MB}
+
+        max_compressed_image_size_mb: ${ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB}
+
+        audit:
+          enabled: true
+          mode: log
+          verbs:
+            - post
+            - put
+            - delete
+            - patch
+          resource_uris:
+            - "/accounts"
+            - "/accounts/{account_name}"
+            - "/accounts/{account_name}/state"
+            - "/accounts/{account_name}/users"
+            - "/accounts/{account_name}/users/{username}"
+            - "/accounts/{account_name}/users/{username}/api-keys"
+            - "/accounts/{account_name}/users/{username}/api-keys/{key_name}"
+            - "/accounts/{account_name}/users/{username}/credentials"
+            - "/rbac-manager/roles"
+            - "/rbac-manager/roles/{role_name}/members"
+            - "/rbac-manager/saml/idps"
+            - "/rbac-manager/saml/idps/{name}"
+            - "/rbac-manager/saml/idps/{name}/user-group-mappings"
+            - "/system/user-groups"
+            - "/system/user-groups/{group_uuid}"
+            - "/system/user-groups/{group_uuid}/roles"
+            - "/system/user-groups/{group_uuid}/users"
+            - "/user/api-keys"
+            - "/user/api-keys/{key_name}"
+            - "/user/credentials"
+
+        metrics:
+          enabled: ${ANCHORE_ENABLE_METRICS}
+          auth_disabled: ${ANCHORE_DISABLE_METRICS_AUTH}
+
+        webhooks:
+          {}
+
+        default_admin_password: "${ANCHORE_ADMIN_PASSWORD}"
+        default_admin_email: ${ANCHORE_ADMIN_EMAIL}
+
+        configuration:
+          api_driven_configuration_enabled: ${ANCHORE_API_DRIVEN_CONFIGURATION_ENABLED}
+
+        keys:
+          secret: "${ANCHORE_SAML_SECRET}"
+          public_key_path: ${ANCHORE_AUTH_PRIVKEY}
+          private_key_path: ${ANCHORE_AUTH_PUBKEY}
+
+        user_authentication:
+          oauth:
+            enabled: ${ANCHORE_OAUTH_ENABLED}
+            default_token_expiration_seconds: ${ANCHORE_OAUTH_TOKEN_EXPIRATION}
+            refresh_token_expiration_seconds: ${ANCHORE_OAUTH_REFRESH_TOKEN_EXPIRATION}
+          hashed_passwords: ${ANCHORE_AUTH_ENABLE_HASHED_PASSWORDS}
+          sso_require_existing_users: ${ANCHORE_SSO_REQUIRES_EXISTING_USERS}
+          allow_api_keys_for_saml_users: false
+          max_api_key_age_days: 365
+          max_api_keys_per_user: 100
+          remove_deleted_user_api_keys_older_than_days: 365
+          disallow_native_users: false
+          log_saml_assertions: false
+        credentials:
+          database:
+            user: "${ANCHORE_DB_USER}"
+            password: "${ANCHORE_DB_PASSWORD}"
+            host: "${ANCHORE_DB_HOST}"
+            port: "${ANCHORE_DB_PORT}"
+            name: "${ANCHORE_DB_NAME}"
+            db_connect_args:
+              timeout: ${ANCHORE_DB_TIMEOUT}
+              ssl: ${ANCHORE_DB_SSL}
+            db_pool_size: ${ANCHORE_DB_POOL_SIZE}
+            db_pool_max_overflow: ${ANCHORE_DB_POOL_MAX_OVERFLOW}
+
+        account_gc:
+          max_resource_gc_chunk: 4096
+          max_deletion_threads: 4
+
+        services:
+          apiext:
+            enabled: true
+            image_content:
+              remove_license_content_from_sbom_return: false
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          analyzer:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            cycle_timer_seconds: 1
+            cycle_timers:
+              image_analyzer: 1
+            analyzer_driver: 'nodocker'
+            layer_cache_enable: ${ANCHORE_LAYER_CACHE_ENABLED}
+            layer_cache_max_gigabytes: ${ANCHORE_LAYER_CACHE_SIZE_GB}
+            enable_hints: ${ANCHORE_HINTS_ENABLED}
+            enable_owned_package_filtering: ${ANCHORE_OWNED_PACKAGE_FILTERING_ENABLED}
+            keep_image_analysis_tmpfiles: ${ANCHORE_KEEP_IMAGE_ANALYSIS_TMPFILES}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          catalog:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            account_prometheus_metrics: <ALLOW_API_CONFIGURATION>
+            cycle_timer_seconds: 1
+            cycle_timers:
+              analyzer_queue: 1
+              archive_tasks: 43200
+              artifact_lifecycle_policy_tasks: 43200
+              events_gc: 43200
+              image_gc: 60
+              image_watcher: 3600
+              k8s_image_watcher: 150
+              notifications: 30
+              policy_bundle_sync: 300
+              policy_eval: 3600
+              repo_watcher: 60
+              resource_metrics: 60
+              service_watcher: 15
+              vulnerability_scan: 14400
+            event_log:
+              max_retention_age_days: 180
+              notification:
+                enabled: false
+                level:
+                - error
+            runtime_inventory:
+              inventory_ttl_days: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_TTL_DAYS}
+              inventory_ingest_overwrite: ${ANCHORE_ENTERPRISE_RUNTIME_INVENTORY_INGEST_OVERWRITE}
+            integrations:
+              integration_health_report_ttl_days: ${ANCHORE_ENTERPRISE_INTEGRATION_HEALTH_REPORTS_TTL_DAYS}
+            image_gc:
+              max_worker_threads: ${ANCHORE_CATALOG_IMAGE_GC_WORKERS}
+            runtime_compliance:
+              object_store_bucket: "runtime_compliance_check"
+            down_analyzer_task_requeue: ${ANCHORE_ANALYZER_TASK_REQUEUE}
+            import_operation_expiration_days: ${ANCHORE_IMPORT_OPERATION_EXPIRATION_DAYS}
+            sbom_vuln_scan:
+              auto_scale: true
+              batch_size: 1
+              pool_size: 1
+            analysis_archive:
+              compression:
+                enabled: true
+                min_size_kbytes: 100
+              enabled: true
+              storage_driver:
+                config:
+                  access_key: itsa
+                  bucket: analysisarchive
+                  region: null
+                  secret_key: test
+                  url: http://myminio.mynamespace.svc.cluster.local:9000
+                name: s3
+            object_store:
+              compression:
+                enabled: true
+                min_size_kbytes: 100
+              storage_driver:
+                config: {}
+                name: db
+              verify_content_digests: true
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          simplequeue:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          policy_engine:
+            enabled: true
+            require_auth: true
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            policy_evaluation_cache_ttl: ${ANCHORE_POLICY_EVAL_CACHE_TTL_SECONDS}
+            enable_package_db_load: ${ANCHORE_POLICY_ENGINE_ENABLE_PACKAGE_DB_LOAD}
+            enable_user_base_image: true
+            vulnerabilities:
+              sync:
+                enabled: true
+                ssl_verify: ${ANCHORE_FEEDS_SSL_VERIFY}
+                connection_timeout_seconds: 3
+                read_timeout_seconds: 60
+                data:
+                  grypedb:
+                    enabled: true
+              matching:
+                exclude:
+                  providers: []
+                  package_types: []
+                default:
+                  search:
+                    by_cpe:
+                      enabled: ${ANCHORE_VULN_MATCHING_DEFAULT_SEARCH_BY_CPE_ENABLED}
+                ecosystem_specific:
+                  dotnet:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_DOTNET_SEARCH_BY_CPE_ENABLED}
+                  golang:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_GOLANG_SEARCH_BY_CPE_ENABLED}
+                  java:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVA_SEARCH_BY_CPE_ENABLED}
+                  javascript:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_JAVASCRIPT_SEARCH_BY_CPE_ENABLED}
+                  python:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_PYTHON_SEARCH_BY_CPE_ENABLED}
+                  ruby:
+                    search:
+                      by_cpe:
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_RUBY_SEARCH_BY_CPE_ENABLED}
+                  stock:
+                    search:
+                      by_cpe:
+                        # Disabling search by CPE for the stock matcher will entirely disable binary-only matches and is not advised
+                        enabled: ${ANCHORE_VULN_MATCHING_ECOSYSTEM_SPECIFIC_STOCK_SEARCH_BY_CPE_ENABLED}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          reports:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            enable_graphiql: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_GRAPHIQL}
+            cycle_timers:
+              reports_scheduled_queries: 600
+            max_async_execution_threads: ${ANCHORE_ENTERPRISE_REPORTS_MAX_ASYNC_EXECUTION_THREADS}
+            async_execution_timeout: ${ANCHORE_ENTERPRISE_REPORTS_ASYNC_EXECUTION_TIMEOUT}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+            use_volume: false
+
+          reports_worker:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            enable_data_ingress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_INGRESS}
+            enable_data_egress: ${ANCHORE_ENTERPRISE_REPORTS_ENABLE_DATA_EGRESS}
+            data_egress_window: ${ANCHORE_ENTERPRISE_REPORTS_DATA_EGRESS_WINDOW}
+            data_refresh_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_REFRESH_MAX_WORKERS}
+            data_load_max_workers: ${ANCHORE_ENTERPRISE_REPORTS_DATA_LOAD_MAX_WORKERS}
+            cycle_timers:
+              reports_extended_runtime_vuln_load: 1800
+              reports_image_egress: 600
+              reports_image_load: 600
+              reports_image_refresh: 7200
+              reports_metrics: 3600
+              reports_runtime_inventory_load: 600
+              reports_tag_egress: 600
+              reports_tag_load: 600
+              reports_tag_refresh: 7200
+            runtime_report_generation:
+              use_legacy_loaders_and_queries: false
+              inventory_images_by_vulnerability: true
+              vulnerabilities_by_k8s_namespace: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_NAMESPACE}
+              vulnerabilities_by_k8s_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_K8S_CONTAINER}
+              vulnerabilities_by_ecs_container: ${ANCHORE_ENTERPRISE_REPORTS_VULNERABILITIES_BY_ECS_CONTAINER}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          notifications:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: '0.0.0.0'
+            port: ${ANCHORE_PORT}
+            max_request_threads: ${ANCHORE_MAX_REQUEST_THREADS}
+            cycle_timers:
+              notifications: 30
+            ui_url: ${ANCHORE_ENTERPRISE_UI_URL}
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
+
+          data_syncer:
+            enabled: true
+            require_auth: true
+            endpoint_hostname: ${ANCHORE_ENDPOINT_HOSTNAME}
+            listen: 0.0.0.0
+            port: ${ANCHORE_PORT}
+            auto_sync_enabled: ${ANCHORE_DATA_SYNC_AUTO_SYNC_ENABLED}
+            upload_dir: /analysis_scratch
+            datasets:
+              vulnerability_db:
+                versions: ["5"]
+              clamav_db:
+                versions: ["1"]
+              kev_db:
+                versions: ["1"]
+            ssl_enable: ${ANCHORE_SSL_ENABLED}
+            ssl_cert: ${ANCHORE_SSL_CERT}
+            ssl_key: ${ANCHORE_SSL_KEY}
     kind: ConfigMap
     metadata:
       annotations:


### PR DESCRIPTION
These two tiny changes fixes the snapshot unittests for configmaps so that they're actually useful/readable.