### PR TITLE
enterprise: update redis image to 7.4.6

### DIFF
--- a/.github/workflows/openshift-test.yaml
+++ b/.github/workflows/openshift-test.yaml
@@ -19,8 +19,8 @@ jobs:
         cluster: [
           {distribution: "openshift", version: "4.13.0-okd"},
           {distribution: "openshift", version: "4.15.0-okd"},
-          {distribution: "gke", version: "1.30"},
-          {distribution: aks, version: "1.30"},
+          {distribution: "gke", version: "1.32"},
+          {distribution: aks, version: "1.32"},
         ]
     runs-on: ubuntu-22.04
     steps:

--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.15.0"
+version: "3.15.1"
 appVersion: "5.21.0"
 kubeVersion: 1.23.x - 1.33.x || 1.23.x-x - 1.33.x-x
 description: |

--- a/stable/enterprise/README.md
+++ b/stable/enterprise/README.md
@@ -1196,6 +1196,8 @@ For the latest updates and features in Anchore Enterprise, see the official [Rel
 
   #### V3.15.0
   - Deploys Anchore Enterprise v5.21.0. See the [Release Notes](https://docs.anchore.com/current/docs/releasenotes/5210/) for more information.
+  #### V3.15.1
+  - Updates the redis image from docker.io/bitnamilegacy/redis:7.0.12-debian-11-r0 to docker.io/redis:7.4.6 to address https://redis.io/blog/security-advisory-cve-2025-49844/
 
 ### V3.14.x
 

--- a/stable/enterprise/tests/__snapshot__/dependency_test.yaml.snap
+++ b/stable/enterprise/tests/__snapshot__/dependency_test.yaml.snap
@@ -143,7 +143,7 @@ should render defaults:
             value: "no"
           - name: REDIS_PORT
             value: "6379"
-        image: docker.io/bitnamilegacy/redis:7.0.12-debian-11-r0
+        image: docker.io/redis:7.4.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -1866,8 +1866,8 @@ ui-redis:
   ##
   image:
     registry: docker.io
-    repository: bitnamilegacy/redis
-    tag: 7.0.12-debian-11-r0
+    repository: redis
+    tag: 7.4.6
     pullSecrets:
       - anchore-enterprise-pullcreds
 


### PR DESCRIPTION
Updates the redis image from docker.io/bitnamilegacy/redis:7.0.12-debian-11-r0 to docker.io/redis:7.4.6 to address https://redis.io/blog/security-advisory-cve-2025-49844/