### PR TITLE
add initialDelaySeconds for readiness probe

### DIFF
--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "3.17.0"
+version: "3.17.1"
 appVersion: "5.23.0"
 kubeVersion: 1.23.x - 1.34.x || 1.23.x-x - 1.34.x-x
 description: |
@@ -23,8 +23,6 @@ sources:
 maintainers:
   - name: zhill
     email: zach@anchore.com
-  - name: btodhunter
-    email: bradyt@anchore.com
   - name: hn23
     email: hung.nguyen@anchore.com
   - name: infrainnovator

--- a/stable/enterprise/templates/_common.tpl
+++ b/stable/enterprise/templates/_common.tpl
@@ -426,6 +426,9 @@ timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
 periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
 failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
 successThreshold: {{ .Values.probes.readiness.successThreshold }}
+{{- with .Values.probes.readiness.initialDelaySeconds }}
+initialDelaySeconds: {{ . }}
+{{- end }}
 {{- end -}}
 
 

--- a/stable/enterprise/templates/ui_deployment.yaml
+++ b/stable/enterprise/templates/ui_deployment.yaml
@@ -105,6 +105,9 @@ spec:
               path: /service/health
               port: {{ $component | lower }}
               scheme: HTTP
+            {{- with .Values.probes.readiness.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            {{- end }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}


### PR DESCRIPTION
Since we have this for liveness it seems to make sense that we should have this for readiness as well.
I am making it so this can be configured if someone so chooses.
Based on our unit tests configuring this setting to 0 or 5 causes more problems than it solves.
Setting it to 120 by default could significantly increase service startup times.
