### PR TITLE
make all anchore enterprise services have a scratch volume by default

### DIFF
--- a/stable/enterprise/templates/reports_deployment.yaml
+++ b/stable/enterprise/templates/reports_deployment.yaml
@@ -29,12 +29,12 @@ spec:
           {{- include "enterprise.common.scratchVolume.details" (merge (dict "component" $component) .) | nindent 10 }}
 
       {{- if or
-            (and .Values.scratchVolume.fixGroupPermissions .Values.securityContext.fsGroup .Values.anchoreConfig.reports.use_volume)
+            (and .Values.scratchVolume.fixGroupPermissions .Values.securityContext.fsGroup)
             (and (.Values.cloudsql.enabled) (.Values.cloudsql.useSideCar))
             (include "enterprise.common.hasInitContainers" (merge (dict "component" $component) .))
         }}
       initContainers:
-        {{- if and .Values.scratchVolume.fixGroupPermissions .Values.securityContext.fsGroup .Values.anchoreConfig.reports.use_volume }}
+        {{- if and .Values.scratchVolume.fixGroupPermissions .Values.securityContext.fsGroup }}
         {{- include "enterprise.common.fixPermissionsInitContainer" . | nindent 8 }}
         {{- end -}}
         {{- if and .Values.cloudsql.enabled .Values.cloudsql.useSideCar }}

--- a/stable/enterprise/templates/ui_deployment.yaml
+++ b/stable/enterprise/templates/ui_deployment.yaml
@@ -24,6 +24,8 @@ spec:
       {{- include "enterprise.common.podSpec" (merge (dict "component" $component) .) | indent 6 }}
       {{- include "enterprise.common.hostAliases" (merge (dict "component" $component) .) | nindent 6 }}
       volumes: {{- include "enterprise.common.extraVolumes" (merge (dict "component" $component) .) | nindent 8 }}
+        - name: anchore-scratch
+          {{- include "enterprise.common.scratchVolume.details" (merge (dict "component" $component) .) | nindent 10 }}
         - name: anchore-license
           secret:
             {{- include "enterprise.licenseSecret" . | nindent 12 }}
@@ -41,10 +43,14 @@ spec:
             secretName: {{ .Values.cloudsql.serviceAccSecretName }}
       {{- end }}
       {{- if or
+            (and .Values.scratchVolume.fixGroupPermissions .Values.securityContext.fsGroup)
             (and (.Values.cloudsql.enabled) (.Values.cloudsql.useSideCar))
             (include "enterprise.common.hasInitContainers" (merge (dict "component" $component) .))
         }}
       initContainers:
+        {{- if and .Values.scratchVolume.fixGroupPermissions .Values.securityContext.fsGroup }}
+        {{- include "enterprise.common.fixPermissionsInitContainer" . | nindent 8 }}
+        {{- end -}}
         {{- if and (.Values.cloudsql.enabled) (.Values.cloudsql.useSideCar) }}
         {{- include "enterprise.common.cloudsqlInitContainer" . | nindent 8 }}
         {{- end }}
@@ -85,6 +91,8 @@ spec:
               protocol: TCP
               name: {{ $component | lower }}
           volumeMounts: {{- include "enterprise.common.extraVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
+            - name: anchore-scratch
+              mountPath: {{ .Values.scratchVolume.mountPath }}
             - name: anchore-license
               mountPath: /home/anchore/license.yaml
               subPath: license.yaml

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -2325,6 +2325,21 @@ ui:
   ##
   serviceAccountName: ""
 
+  ## @param ui.scratchVolume.details [object] Details for the k8s volume to be created for Anchore UI scratch space
+  ## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+  ##
+  scratchVolume:
+    details: {}
+      # ephemeral:
+      #   volumeClaimTemplate:
+      #     spec:
+      #       accessModes:
+      #       - ReadWriteOnce
+      #       resources:
+      #         requests:
+      #           storage: 100Gi
+      #       storageClassName: ""
+
 ##################################################
 ## @section Anchore Pre-Install Job Parameters
 ## Pre-install job uses a Helm pre-install hook


### PR DESCRIPTION
let ui have scratch as well as reports shouldn't need the use_volume field to have a scratch volume