### PR TITLE
feat: support read-only root filesystem for the enterprise chart

### DIFF
--- a/.github/workflows/read-only-test.yaml
+++ b/.github/workflows/read-only-test.yaml
@@ -1,0 +1,168 @@
+name: "Read-only root filesystem test (kind)"
+
+# Deploys the enterprise chart on a read-only root filesystem and exercises both a fresh
+# install and an upgrade, to catch the volume-mount regressions customers hit when running
+# with `containerSecurityContext.readOnlyRootFilesystem: true`. Runs on a single kind node
+# (read-only behaviour is not Kubernetes-version specific) to keep it cheap.
+
+on:
+  pull_request:
+    paths:
+      - 'stable/enterprise/**'
+
+permissions:
+  contents: read
+
+jobs:
+  read-only-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+      with:
+        python-version: '3.10'
+
+    - name: Set up Helm
+      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+      with:
+        version: v3.8.0
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # v2.6.0
+
+    - name: Detect whether the enterprise chart changed
+      id: changed
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        changed=$(ct list-changed --config 'ct-config.yaml' --target-branch "$BASE_REF")
+        if echo "$changed" | grep -q 'stable/enterprise'; then
+          echo "CHANGED=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install kind
+      if: steps.changed.outputs.CHANGED == 'true'
+      uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+      with:
+        node_image: "kindest/node:v1.33.1"
+        config: kind-config.yaml
+        wait: 600s
+
+    - name: Create pullcreds and license secrets
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        kubectl create namespace anchore
+        echo "${ANCHORE_LICENSE}" | base64 --decode > /tmp/anchore-license
+        kubectl --namespace anchore create secret generic anchore-enterprise-license --from-file=license.yaml=/tmp/anchore-license
+        kubectl --namespace anchore create secret docker-registry anchore-enterprise-pullcreds --docker-server=docker.io --docker-username="${DOCKER_USER}" --docker-password="${DOCKER_PASS}"
+      env:
+        ANCHORE_LICENSE: ${{ secrets.B64_ANCHORE_LICENSE }}
+        DOCKER_USER: ${{ secrets.ANCHOREREADONLY_DH_USERNAME }}
+        DOCKER_PASS: ${{ secrets.ANCHOREREADONLY_DH_PAT }}
+
+    - name: Install CNPG operator
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        helm repo add cnpg https://cloudnative-pg.github.io/charts
+        helm repo update
+        helm install cnpg cnpg/cloudnative-pg --namespace cnpg-system --create-namespace --wait
+
+    - name: Deploy CNPG PostgreSQL cluster (Postgres 17 + pg_cron)
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        kubectl apply -f scripts/cnpg/cnpg-cluster.yaml
+        kubectl wait --for=condition=Ready cluster/anchore-db -n anchore --timeout=300s
+        kubectl --namespace anchore get pods
+
+    - name: Build chart dependencies
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+        helm repo update
+        helm dependency build ./stable/enterprise
+
+    # Match how the kind test.yaml selects dev images for the rc5x / nightly branches, so the
+    # read-only test exercises the same image the rest of CI does.
+    - name: Update to rc image if needed
+      if: ${{ steps.changed.outputs.CHANGED == 'true' && (github.event.pull_request.base.ref == 'rc5x' || github.ref_name == 'rc5x') }}
+      run: |
+        {
+          echo 'image: "docker.io/anchore/enterprise-dev:rc"'
+          echo 'ui:'
+          echo '  image: "docker.io/anchore/anchore-on-prem-ui-dev:rc"'
+        } >> stable/enterprise/ci/read-only.yaml
+
+    - name: Update to nightly image if needed
+      if: ${{ steps.changed.outputs.CHANGED == 'true' && (github.event.pull_request.base.ref == 'nightly' || github.ref_name == 'nightly') }}
+      run: |
+        {
+          echo 'image: "docker.io/anchore/enterprise-dev:nightly"'
+          echo 'ui:'
+          echo '  image: "docker.io/anchore/anchore-on-prem-ui-dev:nightly"'
+        } >> stable/enterprise/ci/read-only.yaml
+
+    # ---- Test 1: fresh install on a read-only root filesystem ----
+    - name: "Read-only test: fresh install"
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        helm install ent ./stable/enterprise --namespace anchore \
+          -f stable/enterprise/ci/read-only.yaml --wait --timeout 20m
+        kubectl --namespace anchore get pods
+
+    - name: "Read-only test: verify enforcement and writable mounts"
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        set -euo pipefail
+        # Every Anchore container must actually run with a read-only root filesystem.
+        not_ro=$(kubectl -n anchore get pods -l app.kubernetes.io/name=ent-enterprise \
+          -o jsonpath='{range .items[*].spec.containers[*]}{.securityContext.readOnlyRootFilesystem}{"\n"}{end}' \
+          | grep -vc '^true$' || true)
+        if [[ "$not_ro" -ne 0 ]]; then
+          echo "ERROR: found $not_ro container(s) without readOnlyRootFilesystem=true"; exit 1
+        fi
+        # The rootfs must reject writes while the writable volumes accept them.
+        pod=$(kubectl -n anchore get pod -l app.kubernetes.io/component=api -o jsonpath='{.items[0].metadata.name}')
+        kubectl -n anchore exec "$pod" -- sh -c 'touch /rootfs-probe 2>/dev/null && { echo "ERROR: rootfs is writable"; exit 1; } || echo "rootfs read-only OK"'
+        kubectl -n anchore exec "$pod" -- sh -c 'touch /var/log/anchore/probe && touch /tmp/probe && touch "${ANCHORE_SERVICE_DIR:-/anchore_service}/probe" && echo "writable mounts OK"'
+        # No filesystem errors should appear in any service log.
+        if kubectl -n anchore logs -l app.kubernetes.io/name=ent-enterprise --tail=-1 --prefix 2>/dev/null \
+             | grep -iE "read-only file system|EROFS"; then
+          echo "ERROR: read-only filesystem errors found in service logs"; exit 1
+        fi
+        echo "read-only fresh install verified"
+
+    # ---- Test 2: upgrade on a read-only root filesystem ----
+    # forceScaleDownDeployment makes the pre-upgrade hook scale all deployments to zero, run the
+    # DB upgrade, then scale back up - the same path an app-version-changing upgrade takes, and
+    # the one where the missing volume mounts historically broke customers.
+    - name: "Read-only test: upgrade (pre-upgrade hook + scale down/up)"
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        helm upgrade ent ./stable/enterprise --namespace anchore \
+          -f stable/enterprise/ci/read-only.yaml \
+          --set upgradeJob.forceScaleDownDeployment=true --wait --timeout 20m
+        kubectl --namespace anchore get pods
+
+    - name: "Read-only test: verify upgrade came back healthy"
+      if: steps.changed.outputs.CHANGED == 'true'
+      run: |
+        set -euo pipefail
+        kubectl -n anchore wait --for=condition=available --timeout=600s \
+          deployment -l app.kubernetes.io/name=ent-enterprise
+        if kubectl -n anchore logs -l app.kubernetes.io/name=ent-enterprise --tail=-1 --prefix 2>/dev/null \
+             | grep -iE "read-only file system|EROFS"; then
+          echo "ERROR: read-only filesystem errors found after upgrade"; exit 1
+        fi
+        echo "read-only upgrade verified"
+
+    - name: Dump diagnostics on failure
+      if: ${{ failure() && steps.changed.outputs.CHANGED == 'true' }}
+      run: |
+        kubectl -n anchore get pods -o wide || true
+        kubectl -n anchore describe pods || true
+        kubectl -n anchore logs -l app.kubernetes.io/name=ent-enterprise --tail=100 --prefix || true

--- a/stable/enterprise/ci/read-only.yaml
+++ b/stable/enterprise/ci/read-only.yaml
@@ -1,0 +1,22 @@
+# Values for the read-only root filesystem CI test (.github/workflows/read-only-test.yaml).
+#
+# This file is intentionally NOT named "*-values.yaml" so chart-testing (ct) does not pick
+# it up as an install case; the read-only workflow references it explicitly.
+#
+# It points at the CloudNativePG Postgres the workflow provisions and turns on:
+#   - containerSecurityContext.readOnlyRootFilesystem: overrides the chart default (false) so
+#     the deploy is exercised on a read-only root filesystem.
+#   - anchoreConfig.metrics.enabled: exercises the /analysis_scratch/prometheus_multiproc write
+#     path, i.e. the exact failure customers hit on read-only rootfs.
+postgresql:
+  externalEndpoint: "anchore-db-rw.anchore.svc.cluster.local"
+  auth:
+    username: anchore
+    password: "anchore-postgres,123"
+    database: anchore
+anchoreConfig:
+  default_admin_password: foobar
+  metrics:
+    enabled: true
+containerSecurityContext:
+  readOnlyRootFilesystem: true

--- a/stable/enterprise/templates/_common.tpl
+++ b/stable/enterprise/templates/_common.tpl
@@ -457,6 +457,7 @@ Setup the common anchore volume mounts
   mountPath: /scripts
 - name: anchore-scratch
   mountPath: {{ .Values.scratchVolume.mountPath }}
+{{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) }}
 {{- if .Values.certStoreSecretName }}
 - name: certs
   mountPath: /home/anchore/certs/
@@ -548,6 +549,7 @@ Setup the common anchore volumes
   secret:
     secretName: {{ .Values.cloudsql.serviceAccSecretName }}
 {{- end }}
+{{- include "enterprise.common.writableVolumes" (merge (dict "component" $component) .) }}
 {{- end -}}
 
 {{/*
@@ -626,6 +628,57 @@ When calling this template, .component can be included in the context for compon
   {{- toYaml $componentCtx.containerSecurityContext }}
 {{- else if .Values.containerSecurityContext }}
   {{- toYaml .Values.containerSecurityContext }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Return "true" when the effective container security context for the component enables
+readOnlyRootFilesystem. Mirrors enterprise.common.containerSecurityContext resolution:
+a component-level containerSecurityContext fully replaces the top-level one.
+Used to gate the writable emptyDir volumes Anchore requires on a read-only root filesystem.
+*/}}
+{{- define "enterprise.common.readOnlyRootFilesystem" -}}
+{{- $component := .component -}}
+{{- $componentCtx := index .Values (print $component) -}}
+{{- $ctx := dict -}}
+{{- if and $componentCtx $componentCtx.containerSecurityContext -}}
+  {{- $ctx = $componentCtx.containerSecurityContext -}}
+{{- else if .Values.containerSecurityContext -}}
+  {{- $ctx = .Values.containerSecurityContext -}}
+{{- end -}}
+{{- if $ctx.readOnlyRootFilesystem -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Writable emptyDir volumes required when the container root filesystem is read-only.
+Anchore writes to these paths at runtime (verified against the running image):
+  /var/log/anchore        - logger touches a file here at import time (every service)
+  /tmp                    - file-logging base path (/tmp/anchore-logs) and tempfiles
+  {{ .Values.anchoreConfig.service_dir }}  - service_dir: host_id.json, default policy
+Rendered only when readOnlyRootFilesystem is enabled, so default installs are unchanged.
+*/}}
+{{- define "enterprise.common.writableVolumes" -}}
+{{- if eq (include "enterprise.common.readOnlyRootFilesystem" .) "true" }}
+- name: anchore-logs
+  emptyDir: {}
+- name: anchore-tmp
+  emptyDir: {}
+- name: anchore-service-dir
+  emptyDir: {}
+{{- end }}
+{{- end -}}
+
+{{/*
+Container mounts paired with enterprise.common.writableVolumes. Gated identically.
+*/}}
+{{- define "enterprise.common.writableVolumeMounts" -}}
+{{- if eq (include "enterprise.common.readOnlyRootFilesystem" .) "true" }}
+- name: anchore-logs
+  mountPath: /var/log/anchore
+- name: anchore-tmp
+  mountPath: /tmp
+- name: anchore-service-dir
+  mountPath: {{ .Values.anchoreConfig.service_dir }}
 {{- end }}
 {{- end -}}
 

--- a/stable/enterprise/templates/hooks/post-upgrade/upgrade_job.yaml
+++ b/stable/enterprise/templates/hooks/post-upgrade/upgrade_job.yaml
@@ -36,6 +36,9 @@ spec:
           secret:
             secretName: {{ .Values.cloudsql.serviceAccSecretName }}
       {{- end }}
+      {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+      {{- include "enterprise.common.writableVolumes" (merge (dict "component" $component) .) | nindent 8 }}
+      {{- end }}
       {{- if or
             (and .Values.cloudsql.enabled .Values.cloudsql.useSideCar)
             (include "enterprise.common.hasInitContainers" (merge (dict "component" $component) .))
@@ -75,6 +78,9 @@ spec:
             - name: certs
               mountPath: /home/anchore/certs/
               readOnly: true
+          {{- end }}
+          {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+          {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
         {{- with .Values.upgradeJob.resources }}
           resources: {{- toYaml . | nindent 12 }}

--- a/stable/enterprise/templates/hooks/post-upgrade/upgrade_job.yaml
+++ b/stable/enterprise/templates/hooks/post-upgrade/upgrade_job.yaml
@@ -56,8 +56,8 @@ spec:
         - name: anchore-upgrade
           image: {{ include "enterprise.common.image" . | trim }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-        {{- with .Values.containerSecurityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
+        {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
         {{- end }}
           command: ["/bin/bash", "-c"]
           args:

--- a/stable/enterprise/templates/hooks/pre-install/pre_install_job.yaml
+++ b/stable/enterprise/templates/hooks/pre-install/pre_install_job.yaml
@@ -52,8 +52,8 @@ spec:
         - name: wait-for-db
           image: {{ include "enterprise.common.image" . | trim }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-        {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+        {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
         {{- end }}
           envFrom: {{- include "enterprise.common.envFrom" (merge (dict "hook" true) .) | nindent 12 }}
           volumeMounts: {{- include "enterprise.common.extraVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}

--- a/stable/enterprise/templates/hooks/pre-install/pre_install_job.yaml
+++ b/stable/enterprise/templates/hooks/pre-install/pre_install_job.yaml
@@ -34,6 +34,9 @@ spec:
           secret:
             secretName: {{ .Values.cloudsql.serviceAccSecretName }}
       {{- end }}
+      {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+      {{- include "enterprise.common.writableVolumes" (merge (dict "component" $component) .) | nindent 8 }}
+      {{- end }}
       {{- if or
             (and .Values.cloudsql.enabled .Values.cloudsql.useSideCar)
             (include "enterprise.common.hasInitContainers" (merge (dict "component" $component) .))
@@ -58,6 +61,9 @@ spec:
             - name: certs
               mountPath: /home/anchore/certs/
               readOnly: true
+          {{- end }}
+          {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+          {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
         {{- with .Values.preInstallJob.resources }}
           resources: {{- toYaml . | nindent 12 }}

--- a/stable/enterprise/templates/hooks/pre-upgrade/object_store_analysis_archive_migration_job.yaml
+++ b/stable/enterprise/templates/hooks/pre-upgrade/object_store_analysis_archive_migration_job.yaml
@@ -52,6 +52,9 @@ spec:
           secret:
             secretName: {{ .Values.cloudsql.serviceAccSecretName }}
         {{- end }}
+        {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+        {{- include "enterprise.common.writableVolumes" (merge (dict "component" $component) .) | nindent 8 }}
+        {{- end }}
       initContainers:
         - name: scale-down-anchore
           image: {{ include "enterprise.kubectl.image" . | trim }}
@@ -94,6 +97,9 @@ spec:
                 echo "Database is not ready yet, sleeping 10 seconds..."
                 sleep 10
               done
+          {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+          volumeMounts: {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
+          {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/stable/enterprise/templates/hooks/pre-upgrade/object_store_analysis_archive_migration_job.yaml
+++ b/stable/enterprise/templates/hooks/pre-upgrade/object_store_analysis_archive_migration_job.yaml
@@ -65,8 +65,8 @@ spec:
               while [[ $(kubectl get pods -l app.kubernetes.io/name={{ template "enterprise.fullname" . }} --field-selector=status.phase=Running --no-headers | tee /dev/stderr | wc -l) -gt 0 ]]; do
                 echo 'waiting for pods to go down...' && sleep 5;
               done
-        {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+        {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
         {{- end }}
         {{- with .Values.osaaMigrationJob.resources }}
           resources: {{- toYaml . | nindent 12 }}
@@ -100,8 +100,8 @@ spec:
           {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
           volumeMounts: {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
-          {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+          {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
           {{- with .Values.osaaMigrationJob.resources }}
           resources: {{- toYaml . | nindent 12 }}
@@ -116,8 +116,8 @@ spec:
         - name: migrate-analysis-archive
           image: {{ include "enterprise.common.image" . | trim }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-        {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+        {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
         {{- end }}
           envFrom: {{- include "enterprise.common.envFrom" . | nindent 12 }}
           env: {{- include "enterprise.common.environment" (merge (dict "component" $component) .) | nindent 12 }}

--- a/stable/enterprise/templates/hooks/pre-upgrade/upgrade_job.yaml
+++ b/stable/enterprise/templates/hooks/pre-upgrade/upgrade_job.yaml
@@ -73,8 +73,8 @@ spec:
           {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
           volumeMounts: {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
-          {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+          {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
           {{- with .Values.upgradeJob.resources }}
           resources: {{- toYaml . | nindent 12 }}
@@ -88,8 +88,8 @@ spec:
               while [[ $(kubectl get pods -l app.kubernetes.io/name={{ template "enterprise.fullname" . }} --field-selector=status.phase=Running --no-headers | tee /dev/stderr | wc -l) -gt 0 ]]; do
                 echo 'waiting for pods to go down...' && sleep 5;
               done
-        {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+        {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
         {{- end }}
         {{- with .Values.upgradeJob.resources }}
           resources: {{- toYaml . | nindent 12 }}
@@ -105,8 +105,8 @@ spec:
         - name: upgrade-enterprise-db
           image: {{ include "enterprise.common.image" . | trim }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-        {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+        {{- if or .Values.containerSecurityContext (index .Values $component).containerSecurityContext }}
+          securityContext: {{- include "enterprise.common.containerSecurityContext" (merge (dict "component" $component) .) | nindent 12 }}
         {{- end }}
           envFrom: {{- include "enterprise.common.envFrom" (merge (dict "hook" true) .) | nindent 12 }}
           env: {{- include "enterprise.common.environment" (merge (dict "component" $component) .) | nindent 12 }}

--- a/stable/enterprise/templates/hooks/pre-upgrade/upgrade_job.yaml
+++ b/stable/enterprise/templates/hooks/pre-upgrade/upgrade_job.yaml
@@ -37,6 +37,9 @@ spec:
           secret:
             secretName: {{ .Values.cloudsql.serviceAccSecretName }}
       {{- end }}
+      {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+      {{- include "enterprise.common.writableVolumes" (merge (dict "component" $component) .) | nindent 8 }}
+      {{- end }}
       {{- if or
             (eq (include "enterprise.appVersionChanged" .) "true")
             (and .Values.cloudsql.enabled .Values.cloudsql.useSideCar)
@@ -67,6 +70,9 @@ spec:
                 echo "Database is not ready yet, sleeping 10 seconds..."
                 sleep 10
               done
+          {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+          volumeMounts: {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
+          {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -109,6 +115,9 @@ spec:
             - name: certs
               mountPath: /home/anchore/certs/
               readOnly: true
+          {{- end }}
+          {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+          {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
         {{- with .Values.upgradeJob.resources }}
           resources: {{- toYaml . | nindent 12 }}

--- a/stable/enterprise/templates/ui_deployment.yaml
+++ b/stable/enterprise/templates/ui_deployment.yaml
@@ -30,6 +30,9 @@ spec:
         - name: anchore-ui-config
           configMap:
             name: {{ template "enterprise.ui.fullname" . }}
+      {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+      {{- include "enterprise.common.writableVolumes" (merge (dict "component" $component) .) | nindent 8 }}
+      {{- end }}
       {{- with .Values.certStoreSecretName }}
         - name: certs
           secret:
@@ -95,6 +98,9 @@ spec:
             - name: certs
               mountPath: /home/anchore/certs/
               readOnly: true
+          {{- end }}
+          {{- if eq (include "enterprise.common.readOnlyRootFilesystem" (merge (dict "component" $component) .)) "true" }}
+          {{- include "enterprise.common.writableVolumeMounts" (merge (dict "component" $component) .) | nindent 12 }}
           {{- end }}
           livenessProbe:
             tcpSocket:

--- a/stable/enterprise/tests/readonly_rootfs_test.yaml
+++ b/stable/enterprise/tests/readonly_rootfs_test.yaml
@@ -141,6 +141,11 @@ tests:
       - contains:
           path: spec.template.spec.volumes
           content:
+            name: anchore-tmp
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
             name: anchore-service-dir
             emptyDir: {}
       - contains:
@@ -148,3 +153,13 @@ tests:
           content:
             name: anchore-logs
             mountPath: /var/log/anchore
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-service-dir
+            mountPath: /anchore_service

--- a/stable/enterprise/tests/readonly_rootfs_test.yaml
+++ b/stable/enterprise/tests/readonly_rootfs_test.yaml
@@ -1,0 +1,150 @@
+suite: Read-only Root Filesystem Tests
+templates:
+  - api_deployment.yaml
+  - ui_deployment.yaml
+  - templates/hooks/pre-upgrade/upgrade_job.yaml
+  - anchore_secret.yaml
+  - anchore_configmap.yaml
+  - envvars_configmap.yaml
+  - policybundle_configmap.yaml
+  - ui_secret.yaml
+  - ui_configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+set:
+  postgresql.externalEndpoint: test-postgresql
+  postgresql.auth.username: test-user
+  postgresql.auth.password: test-password
+  postgresql.auth.database: test-db
+  anchoreConfig.policy_engine.vulnerabilities.matching.exclude.providers: []
+  anchoreConfig.policy_engine.vulnerabilities.matching.exclude.package_types: []
+
+tests:
+  # ---------- default (read-only OFF): writable volumes must NOT be added ----------
+  - it: does not add writable volumes to a service pod by default
+    template: api_deployment.yaml
+    documentIndex: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-logs
+            emptyDir: {}
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-logs
+            mountPath: /var/log/anchore
+
+  # ---------- read-only ON: service deployment ----------
+  - it: enforces readOnlyRootFilesystem and mounts writable volumes on a service pod
+    template: api_deployment.yaml
+    documentIndex: 0
+    set:
+      containerSecurityContext.readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-logs
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-tmp
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-service-dir
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-logs
+            mountPath: /var/log/anchore
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-service-dir
+            mountPath: /anchore_service
+
+  # ---------- read-only ON honors a custom service_dir ----------
+  - it: mounts the writable service-dir volume at the configured service_dir
+    template: api_deployment.yaml
+    documentIndex: 0
+    set:
+      containerSecurityContext.readOnlyRootFilesystem: true
+      anchoreConfig.service_dir: /custom_service_dir
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-service-dir
+            mountPath: /custom_service_dir
+
+  # ---------- read-only ON: UI deployment (node image, separate volume wiring) ----------
+  - it: mounts writable volumes and enforces readOnlyRootFilesystem on the UI pod
+    template: ui_deployment.yaml
+    documentIndex: 0
+    set:
+      containerSecurityContext.readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-logs
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-logs
+            mountPath: /var/log/anchore
+
+  - it: does not add writable volumes to the UI pod by default
+    template: ui_deployment.yaml
+    documentIndex: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-logs
+            emptyDir: {}
+
+  # ---------- read-only ON: pre-upgrade hook job ----------
+  - it: mounts writable volumes on the pre-upgrade upgrade job under read-only
+    template: templates/hooks/pre-upgrade/upgrade_job.yaml
+    documentIndex: 0
+    set:
+      containerSecurityContext.readOnlyRootFilesystem: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-logs
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: anchore-service-dir
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: anchore-logs
+            mountPath: /var/log/anchore

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -210,6 +210,13 @@ securityContext:
 ## @param containerSecurityContext The securityContext for all containers
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ##
+## Setting `readOnlyRootFilesystem: true` is supported. When enabled, the chart automatically
+## mounts writable emptyDir volumes at the paths Anchore writes to at runtime
+## (/var/log/anchore, /tmp, and anchoreConfig.service_dir), in addition to the existing
+## scratch volume. No additional configuration is required.
+##   containerSecurityContext:
+##     readOnlyRootFilesystem: true
+##
 containerSecurityContext: {}
 
 ## @param probes.liveness.initialDelaySeconds Initial delay seconds for liveness probe


### PR DESCRIPTION
Anchore writes to several paths at runtime that live on the container root filesystem: /var/log/anchore (logger, at import), /tmp (/tmp/anchore-logs plus tempfiles), and anchoreConfig.service_dir (host_id.json, default policy). When metrics are enabled it also writes /analysis_scratch/prometheus_multiproc. On a read-only root filesystem these writes fail and services crash on startup.

Add writable emptyDir volumes for those paths to every Anchore pod (service deployments, the pre-install/pre-upgrade/post-upgrade/OSAA hook jobs, and the UI), gated on containerSecurityContext.readOnlyRootFilesystem so default installs render identically to before.

Also add:
- ci/read-only.yaml and a kind workflow that installs and upgrades the chart on a read-only root filesystem (metrics on) and verifies enforcement, writable mounts, and the absence of filesystem errors.
- helm unittests asserting the writable volumes/mounts render only when read-only is enabled.

 Signed-off-by: Ben Lang <blang@anchore.com>