### PR TITLE
add a global image registry host override

### DIFF
--- a/stable/anchore-admission-controller/Chart.yaml
+++ b/stable/anchore-admission-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: anchore-admission-controller
-version: 0.8.4
+version: 0.8.5
 appVersion: 0.8.4
 description: A kubernetes admission controller for validating and mutating webhooks that operates against Anchore Engine to make access decisions and annotations
 home: https://github.com/anchore/kubernetes-admission-controller

--- a/stable/anchore-admission-controller/templates/_helpers.tpl
+++ b/stable/anchore-admission-controller/templates/_helpers.tpl
@@ -23,6 +23,44 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Returns the global image registry host override, or an empty string when it isn't set.
+*/}}
+{{- define "anchore-admission-controller.globalImageRegistryHost" -}}
+{{- $global := default dict .Values.global -}}
+{{- default "" $global.imageRegistryHost | trimSuffix "/" -}}
+{{- end -}}
+
+{{/*
+Strips the registry host from a string image reference, returning everything after it.
+The leading path segment is treated as a registry host when it contains a '.' or a ':', or when it
+is 'localhost' - the same rule the docker/OCI reference parsers use. References that don't include a
+registry host (eg. 'anchore/kubernetes-admission-controller') are returned unchanged.
+*/}}
+{{- define "anchore-admission-controller.imageWithoutRegistryHost" -}}
+{{- $ref := trim . -}}
+{{- $parts := splitList "/" $ref -}}
+{{- $host := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $host) (contains ":" $host) (eq $host "localhost")) -}}
+{{- join "/" (rest $parts) -}}
+{{- else -}}
+{{- $ref -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders an image reference with its registry host replaced by global.imageRegistryHost when that is
+set. Accepts: dict "image" <image value> "context" <root context>
+*/}}
+{{- define "anchore-admission-controller.renderImage" -}}
+{{- $globalHost := include "anchore-admission-controller.globalImageRegistryHost" .context -}}
+{{- if $globalHost -}}
+{{- printf "%s/%s" $globalHost (include "anchore-admission-controller.imageWithoutRegistryHost" .image) -}}
+{{- else -}}
+{{- .image | trim -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "anchore-admission-controller.labels" -}}

--- a/stable/anchore-admission-controller/templates/deployment.yaml
+++ b/stable/anchore-admission-controller/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image }}"
+        image: "{{ include "anchore-admission-controller.renderImage" (dict "image" .Values.image "context" .) }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
       {{- with .Values.containerSecurityContext }}
         securityContext: {{- toYaml . | nindent 10 }}

--- a/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
+++ b/stable/anchore-admission-controller/templates/init-ca/init-ca-hook.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: create-ca
-        image:  "{{ .Values.initCa.image }}"
+        image:  "{{ include "anchore-admission-controller.renderImage" (dict "image" .Values.initCa.image "context" .) }}"
       {{- with .Values.containerSecurityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
       {{- end }}

--- a/stable/anchore-admission-controller/templates/init-ca/init-ca-script.yaml
+++ b/stable/anchore-admission-controller/templates/init-ca/init-ca-script.yaml
@@ -15,9 +15,18 @@ data:
     export PATH=$PATH:/tmp/.bin
     cd /tmp/.bin
 
-    curl -L -o jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+    # The tools below are fetched per-architecture. Downloading the amd64 builds on an
+    # arm64 node passes the `which` checks further down but fails with an exec format
+    # error the first time kubectl actually runs.
+    case "$(uname -m)" in
+      x86_64)        ARCH=amd64 ;;
+      aarch64|arm64) ARCH=arm64 ;;
+      *) echo "unsupported architecture: $(uname -m)"; exit 1 ;;
+    esac
+
+    curl -L -o jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${ARCH}
     chmod +x jq
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl
     chmod +x ./kubectl
 
     # creates a client CA, args are sudo, dest-dir, ca-id, purpose

--- a/stable/anchore-admission-controller/tests/global_image_registry_test.yaml
+++ b/stable/anchore-admission-controller/tests/global_image_registry_test.yaml
@@ -1,0 +1,60 @@
+suite: Global Image Registry Host Tests
+templates:
+  - deployment.yaml
+  - init-ca/init-ca-hook.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+
+tests:
+  - it: should leave images untouched when global.imageRegistryHost is not set
+    template: deployment.yaml
+    set:
+      image: anchore/kubernetes-admission-controller:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "anchore/kubernetes-admission-controller:v9.9.9"
+
+  - it: should prefix an image that has no registry host
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: anchore/kubernetes-admission-controller:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/kubernetes-admission-controller:v9.9.9"
+
+  - it: should replace an existing registry host on the image
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: docker.io/anchore/kubernetes-admission-controller:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/kubernetes-admission-controller:v9.9.9"
+
+  - it: should not double up slashes when the registry host has a trailing slash
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com/
+      image: docker.io/anchore/kubernetes-admission-controller:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/kubernetes-admission-controller:v9.9.9"
+
+  - it: should replace the registry host on the init-ca image
+    template: init-ca/init-ca-hook.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      initCa.image: cfssl/cfssl:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/cfssl/cfssl:v9.9.9"

--- a/stable/anchore-admission-controller/tests/init_ca_script_test.yaml
+++ b/stable/anchore-admission-controller/tests/init_ca_script_test.yaml
@@ -1,0 +1,34 @@
+suite: Init CA Script Tests
+templates:
+  - init-ca/init-ca-script.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+
+tests:
+  ## The hook downloads kubectl and jq at install time. Hardcoding the amd64 builds passes the
+  ## `which` guards on an arm64 node and then fails with an exec format error the first time
+  ## kubectl runs, which surfaces as a pre-install job hitting BackoffLimitExceeded.
+  - it: should select the download architecture at runtime
+    asserts:
+      - matchRegex:
+          path: data["init-ca.sh"]
+          pattern: 'case "\$\(uname -m\)" in'
+      - matchRegex:
+          path: data["init-ca.sh"]
+          pattern: 'aarch64\|arm64\) ARCH=arm64'
+
+  - it: should not hardcode an architecture in the download urls
+    asserts:
+      - matchRegex:
+          path: data["init-ca.sh"]
+          pattern: 'jq-linux-\$\{ARCH\}'
+      - matchRegex:
+          path: data["init-ca.sh"]
+          pattern: 'bin/linux/\$\{ARCH\}/kubectl'
+      - notMatchRegex:
+          path: data["init-ca.sh"]
+          pattern: 'linux-amd64|linux/amd64'

--- a/stable/anchore-admission-controller/values.yaml
+++ b/stable/anchore-admission-controller/values.yaml
@@ -5,6 +5,13 @@ fullnameOverride: Null
 replicaCount: 1
 logVerbosity: 3
 
+global:
+  # Setting this overrides the registry host on all image values in this chart (image, initCa.image), so a
+  # mirrored registry only has to be set once. Only the registry host is replaced; the repository and tag are
+  # preserved. eg. with imageRegistryHost: harbor.example.com, anchore/kubernetes-admission-controller:v0.8.4
+  # is pulled from harbor.example.com/anchore/kubernetes-admission-controller:v0.8.4
+  imageRegistryHost: ""
+
 image: "anchore/kubernetes-admission-controller:v0.8.4"
 imagePullPolicy: IfNotPresent
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/stable/ecs-inventory/Chart.yaml
+++ b/stable/ecs-inventory/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
     email: hung.nguyen@anchore.com
 
 type: application
-version: 0.0.17
+version: 0.0.18
 appVersion: "1.4.3"
 
 icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png

--- a/stable/ecs-inventory/README.md
+++ b/stable/ecs-inventory/README.md
@@ -56,6 +56,12 @@ See the [ecs-inventory repo](https://github.com/anchore/ecs-inventory) for more 
 
 ## Parameters
 
+### Global Resource Parameters
+
+| Name                       | Description                                                           | Value |
+| -------------------------- | --------------------------------------------------------------------- | ----- |
+| `global.imageRegistryHost` | overrides the registry host on all Anchore image values in this chart | `""`  |
+
 ### Common Resource Parameters
 
 | Name                                  | Description                                                          | Value                                    |

--- a/stable/ecs-inventory/templates/_helpers.tpl
+++ b/stable/ecs-inventory/templates/_helpers.tpl
@@ -1,4 +1,42 @@
 {{/*
+Returns the global image registry host override, or an empty string when it isn't set.
+*/}}
+{{- define "ecsInventory.globalImageRegistryHost" -}}
+{{- $global := default dict .Values.global -}}
+{{- default "" $global.imageRegistryHost | trimSuffix "/" -}}
+{{- end }}
+
+{{/*
+Strips the registry host from a string image reference, returning everything after it.
+The leading path segment is treated as a registry host when it contains a '.' or a ':', or when it
+is 'localhost' - the same rule the docker/OCI reference parsers use. References that don't include a
+registry host (eg. 'anchore/ecs-inventory') are returned unchanged.
+*/}}
+{{- define "ecsInventory.imageWithoutRegistryHost" -}}
+{{- $ref := trim . -}}
+{{- $parts := splitList "/" $ref -}}
+{{- $host := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $host) (contains ":" $host) (eq $host "localhost")) -}}
+{{- join "/" (rest $parts) -}}
+{{- else -}}
+{{- $ref -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+The image used by the ECS Inventory deployment, with its registry host replaced by
+global.imageRegistryHost when that is set.
+*/}}
+{{- define "ecsInventory.image" -}}
+{{- $globalHost := include "ecsInventory.globalImageRegistryHost" . -}}
+{{- if $globalHost -}}
+{{- printf "%s/%s" $globalHost (include "ecsInventory.imageWithoutRegistryHost" .Values.image) -}}
+{{- else -}}
+{{- .Values.image | trim -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "ecsInventory.selectorLabels" -}}

--- a/stable/ecs-inventory/templates/deployment.yaml
+++ b/stable/ecs-inventory/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          image: {{ .Values.image }}
+          image: {{ include "ecsInventory.image" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           livenessProbe:
             exec:

--- a/stable/ecs-inventory/tests/global_image_registry_test.yaml
+++ b/stable/ecs-inventory/tests/global_image_registry_test.yaml
@@ -1,0 +1,71 @@
+suite: Global Image Registry Host Tests
+templates:
+  - deployment.yaml
+  - secrets.yaml
+  - configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+
+tests:
+  - it: should leave the image untouched when global.imageRegistryHost is not set
+    template: deployment.yaml
+    set:
+      image: docker.io/anchore/ecs-inventory:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/anchore/ecs-inventory:v9.9.9"
+
+  - it: should replace the registry host on the image
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: docker.io/anchore/ecs-inventory:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/ecs-inventory:v9.9.9"
+
+  - it: should prefix an image that has no registry host
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: anchore/ecs-inventory:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/ecs-inventory:v9.9.9"
+
+  - it: should preserve a digest when replacing the registry host
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: docker.io/anchore/ecs-inventory@sha256:0d0ceda52f9958f3c9d173801df77b17ee84e1de6be5c8bc921402991fea853b
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/ecs-inventory@sha256:0d0ceda52f9958f3c9d173801df77b17ee84e1de6be5c8bc921402991fea853b"
+
+  - it: should not double up slashes when the registry host has a trailing slash
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com/
+      image: docker.io/anchore/ecs-inventory:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/ecs-inventory:v9.9.9"
+
+  - it: should strip a registry host that includes a port
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: "localhost:5000"
+      image: registry.example.com:5000/anchore/ecs-inventory:v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "localhost:5000/anchore/ecs-inventory:v9.9.9"

--- a/stable/ecs-inventory/values.yaml
+++ b/stable/ecs-inventory/values.yaml
@@ -1,4 +1,17 @@
 ###################################################
+## @section Global Resource Parameters
+## Global params used by all ECS Inventory resources
+###################################################
+global:
+  ## @param global.imageRegistryHost overrides the registry host on all Anchore image values in this chart
+  ## Setting this replaces the registry host of the image the chart manages (`image`), so a mirrored registry
+  ## only has to be set once. Only the registry host is replaced; the repository, tag and digest are preserved.
+  ## eg. `global.imageRegistryHost: harbor.example.com` pulls `docker.io/anchore/ecs-inventory:v1.4.3` from
+  ## `harbor.example.com/anchore/ecs-inventory:v1.4.3`
+  ##
+  imageRegistryHost: ""
+
+###################################################
 ## @section Common Resource Parameters
 ## Common params used by all ECS Inventory resources
 ###################################################

--- a/stable/enterprise/Chart.yaml
+++ b/stable/enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: enterprise
-version: "4.1.2"
+version: "4.1.3"
 appVersion: "6.1.1"
 kubeVersion: 1.23.x - 1.36.x || 1.23.x-x - 1.36.x-x
 description: |

--- a/stable/enterprise/README.md
+++ b/stable/enterprise/README.md
@@ -19,6 +19,7 @@ See the [Anchore Enterprise Documentation](https://docs.anchore.com) for more de
   - [External Database Requirements](#external-database-requirements)
   - [Installing on Openshift](#installing-on-openshift)
   - [Database Secret Encryption](#database-secret-encryption)
+  - [Using a Private Registry](#using-a-private-registry)
   - [Analyzer Image Layer Cache Configuration](#analyzer-image-layer-cache-configuration)
   - [Configuring Object Storage](#configuring-object-storage)
   - [Configuring Analysis Archive Storage](#configuring-analysis-archive-storage)
@@ -336,6 +337,34 @@ Adding `ANCHORE_DB_ENCRYPTION_KEY_CURRENT` to that secret is what turns encrypti
 With no encryption keys configured (the default), Anchore Enterprise stores registry credentials (and other sensitive values) **as plaintext** in the database. In this mode the chart omits the key env vars from each deployment; the `keys:` list is still rendered in the service config but the unset key variables are dropped, leaving an empty keyring — so no key configuration is required.
 
 This is the default to keep existing deployments working through upgrades. For new installs, enabling encryption is recommended.
+
+### Using a Private Registry
+
+If you mirror the Anchore images into your own registry, set `global.imageRegistryHost` once instead of overriding each image value:
+
+```yaml
+global:
+  imageRegistryHost: harbor.example.com
+```
+
+This replaces the **registry host** on every image the chart deploys — `image`, `ui.image`, `kubectlImage`, `cloudsql.image` and `scratchVolume.fixerInitContainerImage` — while preserving the repository, tag and digest each of those values specifies:
+
+| Image value                                        | Rendered as                                     |
+| -------------------------------------------------- | ----------------------------------------------- |
+| `docker.io/anchore/enterprise:v6.1.1`              | `harbor.example.com/anchore/enterprise:v6.1.1`  |
+| `bitnamilegacy/kubectl:1.30` (no host)             | `harbor.example.com/bitnamilegacy/kubectl:1.30` |
+| `alpine` (no host)                                 | `harbor.example.com/alpine`                     |
+
+The leading path segment of an image value is treated as a registry host when it contains a `.` or a `:`, or when it is `localhost` — the same rule the docker/OCI reference parsers use. Values without a host are prefixed rather than rewritten.
+
+`global.imageRegistryHost` may itself include a path (`harbor.example.com/anchore`), which is prepended in place of the original host — so `docker.io/anchore/enterprise:v6.1.1` becomes `harbor.example.com/anchore/anchore/enterprise:v6.1.1`. If your mirror is flat (one image name per project), override the individual image values instead.
+
+Two things this does **not** cover:
+
+- The bundled `ui-redis` and `prometheus` subcharts. Set those with `ui-redis.image.registry` and the prometheus subchart's own image values.
+- Images you supply yourself in `initContainers` / `extraInitContainers` — those are passed through to the pod spec verbatim.
+
+Credentials for the registry are configured separately, via `imagePullSecretName` and `imageCredentials`.
 
 ### Analyzer Image Layer Cache Configuration
 
@@ -773,10 +802,11 @@ To restore your deployment to using your previous driver configurations:
 
 ### Global Resource Parameters
 
-| Name                      | Description                             | Value |
-| ------------------------- | --------------------------------------- | ----- |
-| `global.fullnameOverride` | overrides the fullname set on resources | `""`  |
-| `global.nameOverride`     | overrides the name set on resources     | `""`  |
+| Name                       | Description                                                              | Value |
+| -------------------------- | ------------------------------------------------------------------------ | ----- |
+| `global.fullnameOverride`  | overrides the fullname set on resources                                  | `""`  |
+| `global.nameOverride`      | overrides the name set on resources                                      | `""`  |
+| `global.imageRegistryHost` | overrides the registry host on all Anchore image values in this chart    | `""`  |
 
 ### Common Resource Parameters
 
@@ -1510,6 +1540,10 @@ For the latest updates and features in Anchore Enterprise, see the official [Rel
 - **Major Chart Version Change (e.g., v0.1.2 -> v1.0.0)**: Signifies an incompatible breaking change that necessitates manual intervention, such as updates to your values file or data migrations.
 - **Minor Chart Version Change (e.g., v0.1.2 -> v0.2.0)**: Indicates a significant change to the deployment that does not require manual intervention.
 - **Patch Chart Version Change (e.g., v0.1.2 -> v0.1.3)**: Indicates a backwards-compatible bug fix or documentation update.
+
+### v4.1.3
+
+- Adds `global.imageRegistryHost`, which overrides the registry host on every Anchore image the chart deploys. See [Using a Private Registry](#using-a-private-registry).
 
 ### v4.1.2
 

--- a/stable/enterprise/templates/_common.tpl
+++ b/stable/enterprise/templates/_common.tpl
@@ -45,7 +45,7 @@ Setup a container for the cloudsql proxy to run in all pods when .Values.cloudsq
 {{- define "enterprise.common.cloudsqlContainer" -}}
 {{- if and (.Values.cloudsql.enabled) (not .Values.cloudsql.useSideCar) -}}
 - name: cloudsql-proxy
-  image: {{ .Values.cloudsql.image }}
+  image: {{ include "enterprise.renderImage" (dict "image" .Values.cloudsql.image "context" .) | trim }}
   imagePullPolicy: {{ .Values.cloudsql.imagePullPolicy }}
 {{- with .Values.containerSecurityContext }}
   securityContext:
@@ -76,7 +76,7 @@ Setup a sidecar container for the cloudsql proxy to run in all pods when .Values
 {{- define "enterprise.common.cloudsqlInitContainer" -}}
 {{- if and (.Values.cloudsql.enabled) (.Values.cloudsql.useSideCar) -}}
 - name: cloudsql-proxy
-  image: {{ .Values.cloudsql.image }}
+  image: {{ include "enterprise.renderImage" (dict "image" .Values.cloudsql.image "context" .) | trim }}
   imagePullPolicy: {{ .Values.cloudsql.imagePullPolicy }}
   restartPolicy: Always
   ports:
@@ -251,7 +251,7 @@ Setup the common fix permissions init container for all pods using a scratch vol
 */}}
 {{- define "enterprise.common.fixPermissionsInitContainer" -}}
 - name: mode-fixer
-  image: {{ .Values.scratchVolume.fixerInitContainerImage }}
+  image: {{ include "enterprise.renderImage" (dict "image" .Values.scratchVolume.fixerInitContainerImage "context" .) | trim }}
   securityContext:
     runAsUser: 0
   volumeMounts:
@@ -320,25 +320,61 @@ app.kubernetes.io/component: {{ $component | lower }}
 {{- end -}}
 
 {{/*
+Returns the global image registry host override, or an empty string when it isn't set.
+*/}}
+{{- define "enterprise.globalImageRegistryHost" -}}
+{{- $global := default dict .Values.global -}}
+{{- default "" $global.imageRegistryHost | trimSuffix "/" -}}
+{{- end }}
+
+{{/*
+Strips the registry host from a string image reference, returning everything after it.
+The leading path segment is treated as a registry host when it contains a '.' or a ':', or when it
+is 'localhost' - the same rule the docker/OCI reference parsers use. References that don't include a
+registry host (eg. 'alpine', 'bitnamilegacy/kubectl:1.30') are returned unchanged.
+*/}}
+{{- define "enterprise.imageWithoutRegistryHost" -}}
+{{- $ref := trim . -}}
+{{- $parts := splitList "/" $ref -}}
+{{- $host := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $host) (contains ":" $host) (eq $host "localhost")) -}}
+{{- join "/" (rest $parts) -}}
+{{- else -}}
+{{- $ref -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Generic image rendering helper.
 Reusable image specification template for Anchore Enterprise
 Accepts:
-- dict "image" <image value>
+- dict "image" <image value> "context" <root context>
 Handles:
 - string values
 - dicts with tag or digest
+- global.imageRegistryHost, which replaces the registry host of either form
 - fails if incomplete
 */}}
 {{- define "enterprise.renderImage" -}}
 {{- $image := .image }}
+{{- $globalHost := include "enterprise.globalImageRegistryHost" .context }}
 {{- if eq (printf "%T" $image) "string" }}
+  {{- if $globalHost }}
+  {{ printf "%s/%s" $globalHost (include "enterprise.imageWithoutRegistryHost" $image) | trim }}
+  {{- else }}
   {{ $image | trim }}
-{{- else if and $image.digest $image.registry $image.repository }}
-  {{ printf "%s/%s@%s" $image.registry $image.repository $image.digest | trim }}
-{{- else if and $image.tag $image.registry $image.repository }}
-  {{ printf "%s/%s:%s" $image.registry $image.repository $image.tag | trim }}
+  {{- end }}
 {{- else }}
+  {{- if $globalHost }}
+    {{- $image = merge (dict "registry" $globalHost) $image }}
+  {{- end }}
+  {{- if and $image.digest $image.registry $image.repository }}
+  {{ printf "%s/%s@%s" $image.registry $image.repository $image.digest | trim }}
+  {{- else if and $image.tag $image.registry $image.repository }}
+  {{ printf "%s/%s:%s" $image.registry $image.repository $image.tag | trim }}
+  {{- else }}
   {{ fail (printf "Invalid image: must include registry, repository, and either tag or digest. Got: %#v" $image) }}
+  {{- end }}
 {{- end }}
 {{- end }}
 
@@ -347,7 +383,7 @@ Create an image specification template that can override the default image
 based on global settings
 */}}
 {{- define "enterprise.common.image" -}}
-{{ include "enterprise.renderImage" (dict "image" .Values.image) }}
+{{ include "enterprise.renderImage" (dict "image" .Values.image "context" .) }}
 {{- end }}
 
 {{/*
@@ -355,7 +391,7 @@ Create an image specification template for the UI that can override the default 
 based on component-specific or global settings
 */}}
 {{- define "enterprise.ui.image" -}}
-{{ include "enterprise.renderImage" (dict "image" .Values.ui.image) }}
+{{ include "enterprise.renderImage" (dict "image" .Values.ui.image "context" .) }}
 {{- end }}
 
 
@@ -363,7 +399,7 @@ based on component-specific or global settings
 Create an image specification template for kubectl
 */}}
 {{- define "enterprise.kubectl.image" -}}
-  {{ include "enterprise.renderImage" (dict "image" .Values.kubectlImage) }}
+  {{ include "enterprise.renderImage" (dict "image" .Values.kubectlImage "context" .) }}
 {{- end }}
 
 {{/*

--- a/stable/enterprise/tests/global_image_registry_test.yaml
+++ b/stable/enterprise/tests/global_image_registry_test.yaml
@@ -1,0 +1,238 @@
+suite: Global Image Registry Host Tests
+templates:
+  - analyzer_deployment.yaml
+  - api_deployment.yaml
+  - catalog_deployment.yaml
+  - notifications_deployment.yaml
+  - policyengine_deployment.yaml
+  - reports_deployment.yaml
+  - reportsworker_deployment.yaml
+  - simplequeue_deployment.yaml
+  - datasyncer_deployment.yaml
+  - ui_deployment.yaml
+  - templates/hooks/pre-upgrade/upgrade_job.yaml
+  - anchore_configmap.yaml
+  - analyzer_configmap.yaml
+  - ui_configmap.yaml
+  - anchore_secret.yaml
+  - ui_secret.yaml
+  - envvars_configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+set:
+  postgresql.externalEndpoint: test-postgresql
+  postgresql.auth.username: test-user
+  postgresql.auth.password: test-password
+  postgresql.auth.database: test-db
+
+backend_test_templates: &backend_test_templates
+  - analyzer_deployment.yaml
+  - api_deployment.yaml
+  - catalog_deployment.yaml
+  - notifications_deployment.yaml
+  - policyengine_deployment.yaml
+  - reports_deployment.yaml
+  - reportsworker_deployment.yaml
+  - simplequeue_deployment.yaml
+  - datasyncer_deployment.yaml
+
+tests:
+  - it: should leave images untouched when global.imageRegistryHost is not set
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      image: "docker.io/anchore/enterprise:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/anchore/enterprise:9.9.9"
+
+  - it: should replace the registry host on the enterprise image
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: "docker.io/anchore/enterprise:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/enterprise:9.9.9"
+
+  - it: should preserve the digest when replacing the registry host
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: "docker.io/anchore/enterprise@sha256:5d6111c2b752eeaf0feee1ba324f98dc879f3fe3fffedaa0d74e73457bf8dfc8"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/enterprise@sha256:5d6111c2b752eeaf0feee1ba324f98dc879f3fe3fffedaa0d74e73457bf8dfc8"
+
+  - it: should prefix images that have no registry host
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: "anchore/enterprise:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/enterprise:9.9.9"
+
+  - it: should prefix single segment images that have no registry host
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image: "enterprise:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/enterprise:9.9.9"
+
+  - it: should support a registry host with a path
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com/anchore
+      image: "docker.io/anchore/enterprise:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/anchore/enterprise:9.9.9"
+
+  - it: should not double up slashes when the registry host has a trailing slash
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com/
+      image: "docker.io/anchore/enterprise:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/enterprise:9.9.9"
+
+  - it: should strip a registry host that includes a port
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: "localhost:5000"
+      image: "registry.example.com:5000/anchore/enterprise:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "localhost:5000/anchore/enterprise:9.9.9"
+
+  - it: should replace the registry on an image passed in as a dict
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image:
+        registry: docker.io
+        repository: anchore/enterprise
+        tag: "9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/enterprise:9.9.9"
+
+  - it: should supply the registry for an image dict that omits one
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image:
+        repository: anchore/enterprise
+        digest: sha256:5d6111c2b752eeaf0feee1ba324f98dc879f3fe3fffedaa0d74e73457bf8dfc8
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/enterprise@sha256:5d6111c2b752eeaf0feee1ba324f98dc879f3fe3fffedaa0d74e73457bf8dfc8"
+
+  - it: should replace the registry host on the ui image
+    template: ui_deployment.yaml
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      ui.image: "docker.io/anchore/enterprise-ui:9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/enterprise-ui:9.9.9"
+
+  - it: should replace the registry host on the kubectl image
+    template: templates/hooks/pre-upgrade/upgrade_job.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      upgradeJob.forceScaleDownDeployment: true
+      kubectlImage: "bitnamilegacy/kubectl:1.30"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: scale-down-anchore
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: "harbor.example.com/bitnamilegacy/kubectl:1.30"
+
+  - it: should replace the registry host on the scratch volume mode-fixer image
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      scratchVolume.fixGroupPermissions: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: mode-fixer
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "harbor.example.com/alpine"
+
+  - it: should replace the registry host on the cloudsql proxy container
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      cloudsql.enabled: true
+      cloudsql.useSideCar: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: cloudsql-proxy
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/cloudsql-docker/gce-proxy:1.37.8"
+
+  - it: should replace the registry host on the cloudsql proxy init container
+    templates: *backend_test_templates
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      cloudsql.enabled: true
+      cloudsql.useSideCar: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: cloudsql-proxy
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "harbor.example.com/cloudsql-docker/gce-proxy:1.37.8"
+
+  - it: should not rewrite user supplied init container images
+    template: analyzer_deployment.yaml
+    documentIndex: 0
+    set:
+      global.imageRegistryHost: harbor.example.com
+      analyzer.initContainers:
+        - name: my-init-container
+          image: example/initContainer:latest
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "example/initContainer:latest"

--- a/stable/enterprise/tests/image_validation_test.yaml
+++ b/stable/enterprise/tests/image_validation_test.yaml
@@ -1,0 +1,41 @@
+## A `fail` in the image helper aborts the render of the whole chart, so this suite is scoped to a
+## single template to keep the error attributed to a predictable document.
+suite: Image Validation Tests
+templates:
+  - analyzer_deployment.yaml
+  - anchore_configmap.yaml
+  - analyzer_configmap.yaml
+  - anchore_secret.yaml
+  - envvars_configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+set:
+  postgresql.externalEndpoint: test-postgresql
+  postgresql.auth.username: test-user
+  postgresql.auth.password: test-password
+  postgresql.auth.database: test-db
+
+tests:
+  - it: should fail on an image dict that omits the registry when no global registry host is set
+    template: analyzer_deployment.yaml
+    set:
+      image:
+        repository: anchore/enterprise
+        tag: "9.9.9"
+    asserts:
+      - failedTemplate:
+          errorPattern: "Invalid image: must include registry, repository, and either tag or digest"
+
+  - it: should fail on an image dict that omits the tag and digest
+    template: analyzer_deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image:
+        repository: anchore/enterprise
+    asserts:
+      - failedTemplate:
+          errorPattern: "Invalid image: must include registry, repository, and either tag or digest"

--- a/stable/enterprise/values.yaml
+++ b/stable/enterprise/values.yaml
@@ -12,6 +12,18 @@ global:
   ##
   nameOverride: ""
 
+  ## @param global.imageRegistryHost overrides the registry host on all Anchore image values in this chart
+  ## Setting this replaces the registry host of every image the chart manages - `image`, `ui.image`, `kubectlImage`,
+  ## `cloudsql.image` and `scratchVolume.fixerInitContainerImage` - so a mirrored registry only has to be set once.
+  ## Only the registry host is replaced; the repository, tag and digest set on each image value are preserved.
+  ## eg. `global.imageRegistryHost: harbor.example.com` pulls `docker.io/anchore/enterprise:v6.1.1` from
+  ## `harbor.example.com/anchore/enterprise:v6.1.1`. Image values with no registry host (eg. `alpine`) are prefixed
+  ## with it instead.
+  ## This does not apply to the bundled ui-redis or prometheus subcharts, or to any images set in initContainers /
+  ## extraInitContainers - set those registries with the subchart's own image values.
+  ##
+  imageRegistryHost: ""
+
 ###################################################
 ## @section Common Resource Parameters
 ## Common params used by all Anchore k8s resources

--- a/stable/k8s-inventory/Chart.yaml
+++ b/stable/k8s-inventory/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-inventory
-version: 0.6.4
+version: 0.6.5
 appVersion: "1.8.4"
 description: A Helm chart for Kubernetes Automated Inventory, which describes which images are in use in a given Kubernetes Cluster
 keywords:

--- a/stable/k8s-inventory/README.md
+++ b/stable/k8s-inventory/README.md
@@ -47,6 +47,12 @@ See the [K8s Inventory repo](https://github.com/anchore/k8s-inventory) for more 
 
 ## Parameters
 
+### Global Resource Parameters
+
+| Name                       | Description                                                           | Value |
+| -------------------------- | --------------------------------------------------------------------- | ----- |
+| `global.imageRegistryHost` | overrides the registry host on all Anchore image values in this chart | `""`  |
+
 ### Common Resource Parameters
 
 | Name                                  | Description                                                                                                             | Value                   |

--- a/stable/k8s-inventory/templates/_helpers.tpl
+++ b/stable/k8s-inventory/templates/_helpers.tpl
@@ -31,6 +31,45 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Returns the global image registry host override, or an empty string when it isn't set.
+*/}}
+{{- define "k8sInventory.globalImageRegistryHost" -}}
+{{- $global := default dict .Values.global -}}
+{{- default "" $global.imageRegistryHost | trimSuffix "/" -}}
+{{- end }}
+
+{{/*
+Strips the registry host from a string image reference, returning everything after it.
+The leading path segment is treated as a registry host when it contains a '.' or a ':', or when it
+is 'localhost' - the same rule the docker/OCI reference parsers use. References that don't include a
+registry host (eg. 'anchore/k8s-inventory') are returned unchanged.
+*/}}
+{{- define "k8sInventory.imageWithoutRegistryHost" -}}
+{{- $ref := trim . -}}
+{{- $parts := splitList "/" $ref -}}
+{{- $host := first $parts -}}
+{{- if and (gt (len $parts) 1) (or (contains "." $host) (contains ":" $host) (eq $host "localhost")) -}}
+{{- join "/" (rest $parts) -}}
+{{- else -}}
+{{- $ref -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+The image used by the K8s Inventory deployment, with its registry host replaced by
+global.imageRegistryHost when that is set.
+*/}}
+{{- define "k8sInventory.image" -}}
+{{- $ref := printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- $globalHost := include "k8sInventory.globalImageRegistryHost" . -}}
+{{- if $globalHost -}}
+{{- printf "%s/%s" $globalHost (include "k8sInventory.imageWithoutRegistryHost" $ref) -}}
+{{- else -}}
+{{- $ref -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "k8sInventory.labels" -}}

--- a/stable/k8s-inventory/templates/deployment.yaml
+++ b/stable/k8s-inventory/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "k8sInventory.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/anchore-k8s-inventory"]
           ports:

--- a/stable/k8s-inventory/tests/global_image_registry_test.yaml
+++ b/stable/k8s-inventory/tests/global_image_registry_test.yaml
@@ -1,0 +1,70 @@
+suite: Global Image Registry Host Tests
+templates:
+  - deployment.yaml
+  - secrets.yaml
+  - configmap.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+chart:
+  version: 9.9.9
+  appVersion: 9.9.9
+set:
+  k8sInventory.anchore.url: http://anchore.example.com
+  k8sInventory.anchore.user: test-user
+  k8sInventory.anchore.password: test-password
+
+tests:
+  - it: should leave the image untouched when global.imageRegistryHost is not set
+    template: deployment.yaml
+    set:
+      image.repository: anchore/k8s-inventory
+      image.tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "anchore/k8s-inventory:v9.9.9"
+
+  - it: should prefix an image that has no registry host
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image.repository: anchore/k8s-inventory
+      image.tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/k8s-inventory:v9.9.9"
+
+  - it: should replace an existing registry host on the image
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image.repository: docker.io/anchore/k8s-inventory
+      image.tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/k8s-inventory:v9.9.9"
+
+  - it: should not double up slashes when the registry host has a trailing slash
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com/
+      image.repository: anchore/k8s-inventory
+      image.tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/k8s-inventory:v9.9.9"
+
+  - it: should fall back to the chart appVersion when no tag is set
+    template: deployment.yaml
+    set:
+      global.imageRegistryHost: harbor.example.com
+      image.repository: anchore/k8s-inventory
+      image.tag: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "harbor.example.com/anchore/k8s-inventory:9.9.9"

--- a/stable/k8s-inventory/values.yaml
+++ b/stable/k8s-inventory/values.yaml
@@ -1,4 +1,17 @@
 ###################################################
+## @section Global Resource Parameters
+## Global params used by all K8s Inventory resources
+###################################################
+global:
+  ## @param global.imageRegistryHost overrides the registry host on all Anchore image values in this chart
+  ## Setting this replaces the registry host of the image the chart manages (`image.repository`), so a mirrored
+  ## registry only has to be set once. Only the registry host is replaced; the repository and tag are preserved.
+  ## eg. `global.imageRegistryHost: harbor.example.com` pulls `anchore/k8s-inventory:v1.8.4` from
+  ## `harbor.example.com/anchore/k8s-inventory:v1.8.4`
+  ##
+  imageRegistryHost: ""
+
+###################################################
 ## @section Common Resource Parameters
 ## Common params used by all K8s Inventory resources
 ###################################################


### PR DESCRIPTION
## Summary

A customer mirroring the Anchore images into their own registry (Harbor) asked for a way to set the registry once instead of overriding every image stanza in `values.yaml`. This adds a single `global.imageRegistryHost` that re-homes every image the chart manages.

```yaml
global:
  imageRegistryHost: harbor.example.com
```

| Image value | Rendered as |
| --- | --- |
| `docker.io/anchore/enterprise:v6.1.1` | `harbor.example.com/anchore/enterprise:v6.1.1` |
| `bitnamilegacy/kubectl:1.30` (no host) | `harbor.example.com/bitnamilegacy/kubectl:1.30` |
| `alpine` (no host) | `harbor.example.com/alpine` |

## Semantics

Only the **registry host** is replaced; the repository, tag and digest on each image value are preserved. The leading path segment counts as a host when it contains a `.` or a `:`, or when it is `localhost` — the same rule the docker/OCI reference parsers use. Values with no host are prefixed rather than rewritten.

The override always wins over the per-image value. Every image value in these charts has a non-empty chart default, so "explicit value wins" would have made the key a permanent no-op — there is no way to tell a chart default from a user-supplied value. The per-image value still controls repository, tag and digest.

Both the string and dict image forms are handled. A dict that omits `registry` now renders successfully when the global host is set, instead of hitting the existing validation `fail`.

## Why `imageRegistryHost` and not `imageRegistry`

Helm merges `global` into every subchart, and the bundled redis and prometheus charts read `.Values.global.imageRegistry` as a **string**:

- `redis/charts/common/templates/_images.tpl:17`
- `prometheus/charts/kube-state-metrics/templates/_helpers.tpl:144`
- `prometheus/charts/prometheus-node-exporter/templates/daemonset.yaml:220`

Reusing that key as a map would have rendered their images as `map[host:harbor.example.com]/redis:7.4.6` — silently broken the moment `ui-redis` or `prometheus` is enabled.

## Scope

| Chart | Images covered | Version |
| --- | --- | --- |
| enterprise | `image`, `ui.image`, `kubectlImage`, `cloudsql.image`, `scratchVolume.fixerInitContainerImage` | 4.1.2 → 4.1.3 |
| k8s-inventory | `image.repository` | 0.6.4 → 0.6.5 |
| ecs-inventory | `image` | 0.0.17 → 0.0.18 |
| anchore-admission-controller | `image`, `initCa.image` | 0.8.4 → 0.8.5 |

All patch bumps — no application version changed.

`cloudsql.image` and `scratchVolume.fixerInitContainerImage` were rendering raw in `_common.tpl` and now go through the shared image helper.

**Out of scope, by design:** the bundled `ui-redis` and `prometheus` subcharts keep their own image values, and images supplied in `initContainers` / `extraInitContainers` are passed through to the pod spec verbatim. Both are called out in the README.

## Testing

Full render of the enterprise chart with `global.imageRegistryHost: harbor.bluestaq.com`, with cloudsql, the scratch-volume mode-fixer, the OSAA migration job and the upgrade job's kubectl init container all enabled:

```
harbor.bluestaq.com/anchore/enterprise@sha256:5d6111…
harbor.bluestaq.com/anchore/enterprise-ui@sha256:0d0ced…
harbor.bluestaq.com/bitnamilegacy/kubectl:1.30
harbor.bluestaq.com/cloudsql-docker/gce-proxy:1.37.8
harbor.bluestaq.com/alpine
docker.io/redis:7.4.6                                  <- subchart, untouched
```

helm-unittest: **614 enterprise / 5 k8s-inventory / 6 ecs-inventory / 5 anchore-admission-controller**, all passing. The 614 includes 16 new enterprise cases plus a small `image_validation_test.yaml`.

k8s-inventory, ecs-inventory and anchore-admission-controller had **no** helm-unittest suites at all. The unittest workflow iterates every changed chart directory, so the enterprise `Chart.yaml` bump would have failed that job on those three charts; each now has a suite covering the new value.

## Notes for reviewers

- CI installs these charts with `global.imageRegistryHost: ""` (a no-op), since pointing a `ci/` values file at a fake registry would just break image pulls. The unit tests are the real coverage.
- Because `anchore-admission-controller` and `k8s-inventory` are touched, `ENTERPRISE_REQUIRED=true` fires in `test.yaml` and each matrix leg stands up an extra enterprise install from the *released* chart. Expect a slow run.
- Unrelated pre-existing issue found while verifying: `helm template` on the enterprise chart fails on `gt .Values.anchoreConfig.analyzer.layer_cache_max_gigabytes 0.0` with "incompatible types for comparison" when the value is supplied via `--set`. It reproduces on a clean `main` and does not affect helm-unittest or normal installs.
