### PR TITLE
docs: regenerate ecs-inventory README from values.yaml

### DIFF
--- a/stable/ecs-inventory/Chart.yaml
+++ b/stable/ecs-inventory/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
     email: hung.nguyen@anchore.com
 
 type: application
-version: 0.0.18
+version: 0.0.19
 appVersion: "1.5.0"
 
 icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png

--- a/stable/ecs-inventory/README.md
+++ b/stable/ecs-inventory/README.md
@@ -61,7 +61,7 @@ See the [ecs-inventory repo](https://github.com/anchore/ecs-inventory) for more 
 | Name                                  | Description                                                          | Value                                    |
 | ------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------- |
 | `replicaCount`                        | Number of replicas for the Ecs Inventory deployment                  | `1`                                      |
-| `image`                               | Image used for all Ecs Inventory deployment deployments              | `docker.io/anchore/ecs-inventory:v1.1.0` |
+| `image`                               | Image used for the ECS Inventory deployment                          | `docker.io/anchore/ecs-inventory:v1.5.0` |
 | `imagePullPolicy`                     | Image pull policy used by all deployments                            | `IfNotPresent`                           |
 | `imagePullSecretName`                 | Name of Docker credentials secret for access to private repos        | `""`                                     |
 | `serviceAccountName`                  | Name of a service account used to run all Anchore Ecs Inventory pods | `""`                                     |
@@ -71,6 +71,7 @@ See the [ecs-inventory repo](https://github.com/anchore/ecs-inventory) for more 
 | `extraEnv`                            | extra environment variables. These will be set on all containers.    | `[]`                                     |
 | `annotations`                         | Common annotations set on all Kubernetes resources                   | `{}`                                     |
 | `deploymentAnnotations`               | annotations to set on the ecs-inventory deployment                   | `{}`                                     |
+| `containerSecurityContext`            | The securityContext for all Anchore ECS Inventory containers         | `{}`                                     |
 | `securityContext.runAsUser`           | The securityContext runAsUser for all Anchore ECS Inventory pods     | `1000`                                   |
 | `securityContext.runAsGroup`          | The securityContext runAsGroup for all Anchore ECS Inventory pods    | `1000`                                   |
 | `securityContext.fsGroup`             | The securityContext fsGroup for all Anchore ECS Inventory pods       | `1000`                                   |
@@ -88,7 +89,6 @@ See the [ecs-inventory repo](https://github.com/anchore/ecs-inventory) for more 
 | `probes.readiness.periodSeconds`      | Period seconds for the readiness probe                               | `15`                                     |
 | `probes.readiness.failureThreshold`   | Failure threshold for the readiness probe                            | `3`                                      |
 | `probes.readiness.successThreshold`   | Success threshold for the readiness probe                            | `1`                                      |
-
 
 ### ecsInventory Parameters ##
 

--- a/stable/ecs-inventory/values.yaml
+++ b/stable/ecs-inventory/values.yaml
@@ -7,7 +7,7 @@
 ##
 replicaCount: 1
 
-## @param image Image used for all Ecs Inventory deployment deployments
+## @param image Image used for the ECS Inventory deployment
 ## use docker.io/anchore/ecs-inventory:v1.5.0-fips-amd64 if you want an image built for fips use
 ##
 image: "docker.io/anchore/ecs-inventory:v1.5.0"


### PR DESCRIPTION
Stacked on #643; merge after it.

The ecs-inventory README parameters table is generated from the `@param` comments in `values.yaml` by the `readme-generator` pre-commit hook, but it had not been regenerated since the chart shipped v1.1.0. This PR reruns the generator so the table reflects the current chart.

Changes:
- `image` default in the README now shows `v1.5.0` (was `v1.1.0`)
- Added the missing `containerSecurityContext` row
- Fixed the duplicated "deployment deployments" wording in the `image` description
- Chart version 0.0.18 → 0.0.19 so chart-testing's version-increment check passes and the refreshed README ships with the 1.5.0 chart

No template changes.