### PR TITLE
fix(ecs-inventory): render config scalars as single-line values

### DIFF
--- a/stable/ecs-inventory/Chart.yaml
+++ b/stable/ecs-inventory/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
     email: hung.nguyen@anchore.com
 
 type: application
-version: 0.0.19
+version: 0.0.20
 appVersion: "1.5.0"
 
 icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png

--- a/stable/ecs-inventory/Chart.yaml
+++ b/stable/ecs-inventory/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
     email: hung.nguyen@anchore.com
 
 type: application
-version: 0.0.18
+version: 0.0.19
 appVersion: "1.5.0"
 
 icon: https://anchore.com/wp-content/uploads/2016/08/anchore.png

--- a/stable/ecs-inventory/README.md
+++ b/stable/ecs-inventory/README.md
@@ -61,7 +61,7 @@ See the [ecs-inventory repo](https://github.com/anchore/ecs-inventory) for more 
 | Name                                  | Description                                                          | Value                                    |
 | ------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------- |
 | `replicaCount`                        | Number of replicas for the Ecs Inventory deployment                  | `1`                                      |
-| `image`                               | Image used for all Ecs Inventory deployment deployments              | `docker.io/anchore/ecs-inventory:v1.1.0` |
+| `image`                               | Image used for the ECS Inventory deployment                          | `docker.io/anchore/ecs-inventory:v1.5.0` |
 | `imagePullPolicy`                     | Image pull policy used by all deployments                            | `IfNotPresent`                           |
 | `imagePullSecretName`                 | Name of Docker credentials secret for access to private repos        | `""`                                     |
 | `serviceAccountName`                  | Name of a service account used to run all Anchore Ecs Inventory pods | `""`                                     |
@@ -71,6 +71,7 @@ See the [ecs-inventory repo](https://github.com/anchore/ecs-inventory) for more 
 | `extraEnv`                            | extra environment variables. These will be set on all containers.    | `[]`                                     |
 | `annotations`                         | Common annotations set on all Kubernetes resources                   | `{}`                                     |
 | `deploymentAnnotations`               | annotations to set on the ecs-inventory deployment                   | `{}`                                     |
+| `containerSecurityContext`            | The securityContext for all Anchore ECS Inventory containers         | `{}`                                     |
 | `securityContext.runAsUser`           | The securityContext runAsUser for all Anchore ECS Inventory pods     | `1000`                                   |
 | `securityContext.runAsGroup`          | The securityContext runAsGroup for all Anchore ECS Inventory pods    | `1000`                                   |
 | `securityContext.fsGroup`             | The securityContext fsGroup for all Anchore ECS Inventory pods       | `1000`                                   |
@@ -88,7 +89,6 @@ See the [ecs-inventory repo](https://github.com/anchore/ecs-inventory) for more 
 | `probes.readiness.periodSeconds`      | Period seconds for the readiness probe                               | `15`                                     |
 | `probes.readiness.failureThreshold`   | Failure threshold for the readiness probe                            | `3`                                      |
 | `probes.readiness.successThreshold`   | Success threshold for the readiness probe                            | `1`                                      |
-
 
 ### ecsInventory Parameters ##
 

--- a/stable/ecs-inventory/templates/configmap.yaml
+++ b/stable/ecs-inventory/templates/configmap.yaml
@@ -20,8 +20,8 @@ data:
       password: $ANCHORE_ECS_INVENTORY_ANCHORE_PASSWORD
       account: {{ .Values.ecsInventory.anchoreAccount | quote }}
       http:
-        insecure: {{ .Values.ecsInventory.anchoreHttpInsecure }}
-        timeout-seconds: {{ .Values.ecsInventory.anchoreHttpTimeoutSeconds }}
+        insecure: {{ .Values.ecsInventory.anchoreHttpInsecure | toJson }}
+        timeout-seconds: {{ .Values.ecsInventory.anchoreHttpTimeoutSeconds | toJson }}
     region: {{ .Values.ecsInventory.awsRegion | quote }}
-    polling-interval-seconds: {{ .Values.ecsInventory.pollingIntervalSeconds }}
-    quiet: {{ .Values.ecsInventory.quiet }}
+    polling-interval-seconds: {{ .Values.ecsInventory.pollingIntervalSeconds | toJson }}
+    quiet: {{ .Values.ecsInventory.quiet | toJson }}

--- a/stable/ecs-inventory/values.yaml
+++ b/stable/ecs-inventory/values.yaml
@@ -7,7 +7,7 @@
 ##
 replicaCount: 1
 
-## @param image Image used for all Ecs Inventory deployment deployments
+## @param image Image used for the ECS Inventory deployment
 ## use docker.io/anchore/ecs-inventory:v1.5.0-fips-amd64 if you want an image built for fips use
 ##
 image: "docker.io/anchore/ecs-inventory:v1.5.0"


### PR DESCRIPTION
Stacked on #644 (which is stacked on #643); merge after both.

Four values in `templates/configmap.yaml` were interpolated unquoted: `ecsInventory.quiet`, `ecsInventory.pollingIntervalSeconds`, `ecsInventory.anchoreHttpInsecure`, and `ecsInventory.anchoreHttpTimeoutSeconds`. Because `config.yaml` is a block scalar, a multi-line string passed for any of them was emitted as raw YAML and picked up by the agent as additional config keys. The string-typed fields were already safe because `quote` escapes newlines.

This renders the four fields with `toJson`, which leaves booleans and integers exactly as before and turns any string into a single-line quoted scalar.

Verified:
- `helm template` output with default values is byte-identical apart from the chart version label
- `--set-string ecsInventory.pollingIntervalSeconds=90` renders `"90"` and the v1.5.0 agent still starts (viper decodes it weakly)
- A multi-line `quiet` value now renders as one quoted string and the agent exits with `'quiet' cannot parse value as 'bool'` instead of applying the embedded keys
- `helm lint` passes

Chart version 0.0.19 → 0.0.20 for chart-testing's version-increment check.